### PR TITLE
plot low quality (anti-aliasing off) while dragging

### DIFF
--- a/demos/src/plottable-const/Form1.cs
+++ b/demos/src/plottable-const/Form1.cs
@@ -27,6 +27,7 @@ namespace plottable_const
         {
             data = ScottPlot.DataGen.RandomWalk(rand, 10_000_000);
             signal = scottPlotUC1.plt.PlotSignalConst(data);
+            scottPlotUC1.useDynamicAA = true;
             scottPlotUC1.plt.Benchmark();
             scottPlotUC1.Render();
         }

--- a/demos/src/plottable-const/Form1.cs
+++ b/demos/src/plottable-const/Form1.cs
@@ -27,7 +27,6 @@ namespace plottable_const
         {
             data = ScottPlot.DataGen.RandomWalk(rand, 10_000_000);
             signal = scottPlotUC1.plt.PlotSignalConst(data);
-            scottPlotUC1.lowQualityWhileDragging = true;
             scottPlotUC1.plt.Benchmark();
             scottPlotUC1.Render();
         }

--- a/demos/src/plottable-const/Form1.cs
+++ b/demos/src/plottable-const/Form1.cs
@@ -27,7 +27,7 @@ namespace plottable_const
         {
             data = ScottPlot.DataGen.RandomWalk(rand, 10_000_000);
             signal = scottPlotUC1.plt.PlotSignalConst(data);
-            scottPlotUC1.useDynamicAA = true;
+            scottPlotUC1.lowQualityWhileDragging = true;
             scottPlotUC1.plt.Benchmark();
             scottPlotUC1.Render();
         }

--- a/src/ScottPlot/MouseTracker.cs
+++ b/src/ScottPlot/MouseTracker.cs
@@ -13,6 +13,7 @@ namespace ScottPlot
     {
         public Stopwatch mouseDownStopwatch = new Stopwatch();
         private Plottable draggingObject;
+        public bool lowQualityWhileDragging = true;
 
         private readonly Settings settings;
         public MouseTracker(Settings settings)

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -136,26 +136,21 @@ namespace ScottPlot
             Renderer.Benchmark(settings);
         }
 
-        public Bitmap GetBitmap(bool antiAliasFigure, bool antiAliasDataa)
-        {
-            // save currently using AA settings
-            bool currentAAFigure = settings.antiAliasFigure;
-            bool currentAAData = settings.antiAliasData;
-            // set new settings for render
-            settings.antiAliasFigure = antiAliasFigure;
-            settings.antiAliasData = antiAliasDataa;
-
-            RenderBitmap();
-            // restore saved AA settings
-            settings.antiAliasFigure = currentAAFigure;
-            settings.antiAliasData = currentAAData;
-            return settings.bmpFigure;
-        }
-
-        public Bitmap GetBitmap(bool renderFirst = true)
-        {
-            if (renderFirst)
-                RenderBitmap();
+        public Bitmap GetBitmap(bool renderFirst = true, bool lowQuality = false)
+        {          
+            if (lowQuality)
+            {
+                bool currentAAData = settings.antiAliasData; // save currently using AA setting
+                settings.antiAliasData = false; // disable AA for render
+                if (renderFirst)
+                    RenderBitmap();
+                settings.antiAliasData = currentAAData; // restore saved AA setting
+            }
+            else
+            {
+                if (renderFirst)
+                    RenderBitmap();
+            }                            
             return settings.bmpFigure;
         }
 

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -136,6 +136,22 @@ namespace ScottPlot
             Renderer.Benchmark(settings);
         }
 
+        public Bitmap GetBitmap(bool antiAliasFigure, bool antiAliasDataa)
+        {
+            // save currently using AA settings
+            bool currentAAFigure = settings.antiAliasFigure;
+            bool currentAAData = settings.antiAliasData;
+            // set new settings for render
+            settings.antiAliasFigure = antiAliasFigure;
+            settings.antiAliasData = antiAliasDataa;
+
+            RenderBitmap();
+            // restore saved AA settings
+            settings.antiAliasFigure = currentAAFigure;
+            settings.antiAliasData = currentAAData;
+            return settings.bmpFigure;
+        }
+
         public Bitmap GetBitmap(bool renderFirst = true)
         {
             if (renderFirst)

--- a/src/ScottPlot/ScottPlotUC.cs
+++ b/src/ScottPlot/ScottPlotUC.cs
@@ -8,9 +8,6 @@ namespace ScottPlot
     public partial class ScottPlotUC : UserControl
     {
         public Plot plt = new Plot();
-
-        public bool lowQualityWhileDragging = true;
-
         private bool currentlyRendering = false;
         private ContextMenuStrip rightClickMenu;
 
@@ -74,7 +71,7 @@ namespace ScottPlot
 
             if (e.Button != MouseButtons.None)
             {
-                Render(true, lowQualityWhileDragging);
+                Render(skipIfCurrentlyRendering: true, lowQuality: plt.mouseTracker.lowQualityWhileDragging);
                 OnMouseDragged(EventArgs.Empty);
             }
         }
@@ -105,9 +102,11 @@ namespace ScottPlot
                 if (plt.GetPlottables().Count > 0)
                     if ((plt.GetPlottables()[0] is PlottableScatter) || (plt.GetPlottables()[0] is PlottableSignal))
                         saveDataMenuItem.Enabled = true;
-
+                
                 rightClickMenu.Items.Add("Auto-Axis");
                 rightClickMenu.Items.Add("Clear");
+                rightClickMenu.Items.Add(new ToolStripSeparator());
+                rightClickMenu.Items.Add("Toggle quality while dragging");
                 rightClickMenu.Items.Add(new ToolStripSeparator());
                 rightClickMenu.Items.Add("Help");
 

--- a/src/ScottPlot/ScottPlotUC.cs
+++ b/src/ScottPlot/ScottPlotUC.cs
@@ -8,6 +8,14 @@ namespace ScottPlot
     public partial class ScottPlotUC : UserControl
     {
         public Plot plt = new Plot();
+
+        public bool useDynamicAA = false;
+
+        private bool dynamicAAFigureLow = true;  // setting for AAFigure at interactions
+        private bool dynamicAADataLow = false;   // settings for AAData at interactions
+        private bool dynamicAAFigureHigh = true; // setting for AAFigure at Static
+        private bool dynamicAADataHigh = true;   // setting for AAData at Static
+
         private bool currentlyRendering = false;
         private ContextMenuStrip rightClickMenu;
 

--- a/src/ScottPlot/ScottPlotUC.cs
+++ b/src/ScottPlot/ScottPlotUC.cs
@@ -21,6 +21,18 @@ namespace ScottPlot
             PbPlot_SizeChanged(null, null);
         }
 
+        public void Render(bool skipIfCurrentlyRendering, bool antiAliasFigure, bool antiAliasData)
+        {
+            if (!(skipIfCurrentlyRendering && currentlyRendering))
+            {
+                currentlyRendering = true;
+                pbPlot.Image = plt.GetBitmap(antiAliasFigure, antiAliasData);
+                if (plt.mouseTracker.IsDraggingSomething())
+                    Application.DoEvents();
+                currentlyRendering = false;
+            }
+        }
+
         public void Render(bool skipIfCurrentlyRendering = false)
         {
             if (!(skipIfCurrentlyRendering && currentlyRendering))

--- a/src/ScottPlot/ScottPlotUC.cs
+++ b/src/ScottPlot/ScottPlotUC.cs
@@ -9,7 +9,7 @@ namespace ScottPlot
     {
         public Plot plt = new Plot();
 
-        public bool useDynamicAA = false;
+        public bool lowQualityWhileDragging = false;
 
         private bool dynamicAAFigureLow = true;  // setting for AAFigure at interactions
         private bool dynamicAADataLow = false;   // settings for AAData at interactions
@@ -29,24 +29,12 @@ namespace ScottPlot
             PbPlot_SizeChanged(null, null);
         }
 
-        public void Render(bool skipIfCurrentlyRendering, bool antiAliasFigure, bool antiAliasData)
+        public void Render(bool skipIfCurrentlyRendering = false, bool lowQuality = false)
         {
             if (!(skipIfCurrentlyRendering && currentlyRendering))
             {
                 currentlyRendering = true;
-                pbPlot.Image = plt.GetBitmap(antiAliasFigure, antiAliasData);
-                if (plt.mouseTracker.IsDraggingSomething())
-                    Application.DoEvents();
-                currentlyRendering = false;
-            }
-        }
-
-        public void Render(bool skipIfCurrentlyRendering = false)
-        {
-            if (!(skipIfCurrentlyRendering && currentlyRendering))
-            {
-                currentlyRendering = true;
-                pbPlot.Image = plt.GetBitmap();
+                pbPlot.Image = plt.GetBitmap(true, lowQuality);
                 if (plt.mouseTracker.IsDraggingSomething())
                     Application.DoEvents();
                 currentlyRendering = false;
@@ -56,10 +44,7 @@ namespace ScottPlot
         private void PbPlot_SizeChanged(object sender, EventArgs e)
         {
             plt.Resize(Width, Height);
-            if (useDynamicAA)
-                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings for Resize
-            else
-                Render(skipIfCurrentlyRendering: false);
+            Render(skipIfCurrentlyRendering: false);
         }
 
         private void PbPlot_MouseDown(object sender, MouseEventArgs e)
@@ -94,10 +79,7 @@ namespace ScottPlot
 
             if (e.Button != MouseButtons.None)
             {
-                if (useDynamicAA)
-                    Render(true, dynamicAAFigureLow, dynamicAADataLow); // use low settings on pan or zoom
-                else
-                    Render(skipIfCurrentlyRendering: true);
+                Render(true, lowQualityWhileDragging);
                 OnMouseDragged(EventArgs.Empty);
             }
         }
@@ -105,10 +87,7 @@ namespace ScottPlot
         private void PbPlot_MouseUp(object sender, MouseEventArgs e)
         {
             plt.mouseTracker.MouseUp(e.Location);
-            if (useDynamicAA)
-                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings then mouse up
-            else
-                Render(skipIfCurrentlyRendering: false);
+            Render(skipIfCurrentlyRendering: false);
             if (plt.mouseTracker.PlottableUnderCursor(e.Location) != null)
                 OnMouseDropPlottable(EventArgs.Empty);
         }
@@ -118,10 +97,7 @@ namespace ScottPlot
             if (e.Button == MouseButtons.Middle)
             {
                 plt.AxisAuto();
-                if (useDynamicAA)
-                    Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings on middle button (AutoAxis)
-                else
-                    Render(skipIfCurrentlyRendering: false);
+                Render(skipIfCurrentlyRendering: false);
             }
             else if (e.Button == MouseButtons.Right && plt.mouseTracker.mouseDownStopwatch.ElapsedMilliseconds < 100)
             {
@@ -161,10 +137,7 @@ namespace ScottPlot
         private void PbPlot_MouseDoubleClick(object sender, MouseEventArgs e)
         {
             plt.Benchmark(toggle: true);
-            if (useDynamicAA)
-                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings on double click?, is this render before context menu
-            else
-                Render(skipIfCurrentlyRendering: false);
+            Render(skipIfCurrentlyRendering: false);
         }
 
         private void PbPlot_MouseWheel(object sender, MouseEventArgs e)
@@ -175,22 +148,14 @@ namespace ScottPlot
                 plt.AxisZoom(1 + zoomAmount, 1 + zoomAmount, zoomCenter);
             else
                 plt.AxisZoom(1 - zoomAmount, 1 - zoomAmount, zoomCenter);
-            // lost in performance, must call high only on last MouseWhell, but no way to check
-            // may be implement on timer, because typicaly mouse wheel event called close in time
-            if (useDynamicAA)
-                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); 
-            else
-                Render(skipIfCurrentlyRendering: false);
+            Render(skipIfCurrentlyRendering: false);
         }
 
         private void RightClickMenuItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             rightClickMenu.Hide();
             Tools.RightClickMenuItemClicked(e.ClickedItem, rightClickMenu, plt);
-            if (useDynamicAA)
-                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings
-            else
-                Render(skipIfCurrentlyRendering: false);
+            Render(skipIfCurrentlyRendering: false);
         }
 
         public event EventHandler MouseDownOnPlottable;

--- a/src/ScottPlot/ScottPlotUC.cs
+++ b/src/ScottPlot/ScottPlotUC.cs
@@ -11,11 +11,6 @@ namespace ScottPlot
 
         public bool lowQualityWhileDragging = false;
 
-        private bool dynamicAAFigureLow = true;  // setting for AAFigure at interactions
-        private bool dynamicAADataLow = false;   // settings for AAData at interactions
-        private bool dynamicAAFigureHigh = true; // setting for AAFigure at Static
-        private bool dynamicAADataHigh = true;   // setting for AAData at Static
-
         private bool currentlyRendering = false;
         private ContextMenuStrip rightClickMenu;
 

--- a/src/ScottPlot/ScottPlotUC.cs
+++ b/src/ScottPlot/ScottPlotUC.cs
@@ -56,7 +56,10 @@ namespace ScottPlot
         private void PbPlot_SizeChanged(object sender, EventArgs e)
         {
             plt.Resize(Width, Height);
-            Render(skipIfCurrentlyRendering: false);
+            if (useDynamicAA)
+                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings for Resize
+            else
+                Render(skipIfCurrentlyRendering: false);
         }
 
         private void PbPlot_MouseDown(object sender, MouseEventArgs e)
@@ -91,7 +94,10 @@ namespace ScottPlot
 
             if (e.Button != MouseButtons.None)
             {
-                Render(skipIfCurrentlyRendering: true);
+                if (useDynamicAA)
+                    Render(true, dynamicAAFigureLow, dynamicAADataLow); // use low settings on pan or zoom
+                else
+                    Render(skipIfCurrentlyRendering: true);
                 OnMouseDragged(EventArgs.Empty);
             }
         }
@@ -99,7 +105,10 @@ namespace ScottPlot
         private void PbPlot_MouseUp(object sender, MouseEventArgs e)
         {
             plt.mouseTracker.MouseUp(e.Location);
-            Render(skipIfCurrentlyRendering: false);
+            if (useDynamicAA)
+                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings then mouse up
+            else
+                Render(skipIfCurrentlyRendering: false);
             if (plt.mouseTracker.PlottableUnderCursor(e.Location) != null)
                 OnMouseDropPlottable(EventArgs.Empty);
         }
@@ -109,7 +118,10 @@ namespace ScottPlot
             if (e.Button == MouseButtons.Middle)
             {
                 plt.AxisAuto();
-                Render(skipIfCurrentlyRendering: false);
+                if (useDynamicAA)
+                    Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings on middle button (AutoAxis)
+                else
+                    Render(skipIfCurrentlyRendering: false);
             }
             else if (e.Button == MouseButtons.Right && plt.mouseTracker.mouseDownStopwatch.ElapsedMilliseconds < 100)
             {
@@ -149,7 +161,10 @@ namespace ScottPlot
         private void PbPlot_MouseDoubleClick(object sender, MouseEventArgs e)
         {
             plt.Benchmark(toggle: true);
-            Render(skipIfCurrentlyRendering: false);
+            if (useDynamicAA)
+                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings on double click?, is this render before context menu
+            else
+                Render(skipIfCurrentlyRendering: false);
         }
 
         private void PbPlot_MouseWheel(object sender, MouseEventArgs e)
@@ -160,14 +175,22 @@ namespace ScottPlot
                 plt.AxisZoom(1 + zoomAmount, 1 + zoomAmount, zoomCenter);
             else
                 plt.AxisZoom(1 - zoomAmount, 1 - zoomAmount, zoomCenter);
-            Render(skipIfCurrentlyRendering: false);
+            // lost in performance, must call high only on last MouseWhell, but no way to check
+            // may be implement on timer, because typicaly mouse wheel event called close in time
+            if (useDynamicAA)
+                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); 
+            else
+                Render(skipIfCurrentlyRendering: false);
         }
 
         private void RightClickMenuItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             rightClickMenu.Hide();
             Tools.RightClickMenuItemClicked(e.ClickedItem, rightClickMenu, plt);
-            Render(skipIfCurrentlyRendering: false);
+            if (useDynamicAA)
+                Render(false, dynamicAAFigureHigh, dynamicAADataHigh); // use high settings
+            else
+                Render(skipIfCurrentlyRendering: false);
         }
 
         public event EventHandler MouseDownOnPlottable;

--- a/src/ScottPlot/ScottPlotUC.cs
+++ b/src/ScottPlot/ScottPlotUC.cs
@@ -9,7 +9,7 @@ namespace ScottPlot
     {
         public Plot plt = new Plot();
 
-        public bool lowQualityWhileDragging = false;
+        public bool lowQualityWhileDragging = true;
 
         private bool currentlyRendering = false;
         private ContextMenuStrip rightClickMenu;

--- a/src/ScottPlot/ScottPlotWPF.xaml.cs
+++ b/src/ScottPlot/ScottPlotWPF.xaml.cs
@@ -21,6 +21,9 @@ namespace ScottPlot
     public partial class ScottPlotWPF : UserControl
     {
         public Plot plt = new Plot();
+
+        public bool lowQualityWhileDragging = false;
+
         private bool currentlyRendering = false;
 
         public ScottPlotWPF()
@@ -31,12 +34,12 @@ namespace ScottPlot
             CanvasPlot_SizeChanged(null, null);
         }
 
-        public void Render(bool skipIfCurrentlyRendering = false)
+        public void Render(bool skipIfCurrentlyRendering = false, bool lowQuality = false)
         {
             if (!(skipIfCurrentlyRendering && currentlyRendering))
             {
                 currentlyRendering = true;
-                imagePlot.Source = Tools.bmpImageFromBmp(plt.GetBitmap());
+                imagePlot.Source = Tools.bmpImageFromBmp(plt.GetBitmap(true, lowQuality));
                 currentlyRendering = false;
             }
         }
@@ -57,7 +60,7 @@ namespace ScottPlot
         {
             plt.mouseTracker.MouseMove(e.GetPosition(this));
             if ((Mouse.LeftButton == MouseButtonState.Pressed) || (Mouse.RightButton == MouseButtonState.Pressed))
-                Render(skipIfCurrentlyRendering: true);
+                Render(skipIfCurrentlyRendering: true, lowQualityWhileDragging);
         }
 
         private void UserControl_MouseUp(object sender, MouseButtonEventArgs e)

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -157,6 +157,9 @@ namespace ScottPlot
                     rightClickMenu.Hide();
                     plt.Clear();
                     break;
+                case "Toggle quality while dragging":
+                    plt.mouseTracker.lowQualityWhileDragging = !plt.mouseTracker.lowQualityWhileDragging;
+                    break;
                 case "About":
                     rightClickMenu.Hide();
                     System.Diagnostics.Process.Start("https://github.com/swharden/ScottPlot");


### PR DESCRIPTION
Mode enabled by set lowQualityWhileDragging=true in ScottPlotUC.
In this mode AA disabled for user interactions with plot like paning or zooming.
But then user stop interacting last render call with settings.antiAliasData.
This makes good speed improvment during user interactions, in cost of image quality.
But plot always looks perfect at static.
AA for figure never turned off, only for data.