### PR TITLE
singlePrecision trees for SignalConst

### DIFF
--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -369,7 +369,8 @@ namespace ScottPlot
             Color? color = null,
             double lineWidth = 1,
             double markerSize = 5,
-            string label = null
+            string label = null,
+            bool singlePrecision = false
             )
         {
             if (color == null)
@@ -384,7 +385,8 @@ namespace ScottPlot
                 lineWidth: lineWidth,
                 markerSize: markerSize,
                 label: label,
-                useParallel: settings.useParallel
+                useParallel: settings.useParallel,
+                singlePrecision: singlePrecision
                 );
 
             settings.plottables.Add(signal);

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -177,7 +177,7 @@ namespace ScottPlot
 
                 TreesReady = true;
             }
-            catch (System.OutOfMemoryException ex)
+            catch (System.OutOfMemoryException)
             {
                 TreeMin = null;
                 TreeMax = null;

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace ScottPlot
         // using 4 x signal memory in worst case: ys.Length is (Pow2 +1);        
         double[] TreeMin;
         double[] TreeMax;
+        private int n = 0; // size of each Tree
         public bool TreesReady = false;
         public PlottableSignalConst(double[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel) : base(ys, sampleRate, xOffset, yOffset, color, lineWidth, markerSize, label, useParallel)
         {
@@ -28,8 +30,7 @@ namespace ScottPlot
         public void updateData(int index, double newValue)
         {
             ys[index] = newValue;
-            // Update Tree, can be optimized
-            int n = TreeMin.Length;
+            // Update Tree, can be optimized            
             if (index == ys.Length - 1) // last elem haven't pair
             {
                 TreeMin[n / 2 + index / 2] = ys[index];
@@ -64,8 +65,7 @@ namespace ScottPlot
         }
 
         public void updateData(int from, int to, double[] newData, int fromData = 0)
-        {
-            int n = TreeMin.Length;
+        {            
             //update source signal
             for (int i = from; i < to; i++)
             {
@@ -149,7 +149,7 @@ namespace ScottPlot
             try
             {
                 // Size up to pow2
-                int n = (1 << ((int)Math.Log(ys.Length - 1, 2) + 1));
+                n = (1 << ((int)Math.Log(ys.Length - 1, 2) + 1));
                 TreeMin = new double[n];
                 TreeMax = new double[n];
                 // fill bottom layer of tree                
@@ -198,8 +198,7 @@ namespace ScottPlot
             }
 
             lowestValue = double.MaxValue;
-            highestValue = double.MinValue;
-            int n = TreeMin.Length;
+            highestValue = double.MinValue;            
             if (l > r)
             {
                 int temp = r;

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -258,8 +258,15 @@ namespace ScottPlot
             TreesReady = false;
             try
             {
+                if (ys.Length == 0)
+                    throw new ArgumentOutOfRangeException($"Array cant't be empty");
                 // Size up to pow2
-                n = (1 << ((int)Math.Log(ys.Length - 1, 2) + 1));
+                if (ys.Length > 0x40_00_00_00) // pow 2 must be more then int.MaxValue
+                    throw new ArgumentOutOfRangeException($"Array higher then {0x40_00_00_00} not supported by SignalConst");
+                int pow2 = 1;
+                while (pow2 < 0x40_00_00_00 && pow2 < ys.Length)
+                    pow2 <<= 1;
+                n = pow2;
                 if (singlePrecision == false)
                 {
                     TreeMin = new double[n];

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -9,14 +9,17 @@ namespace ScottPlot
     // Variation of PlottableSignal that uses a segmented tree for faster min/max range queries
     // - frequent min/max lookups are a bottleneck displaying large signals
     // - limited to 60M points (250M in x64 mode) due to memory (tree uses from 2X to 4X memory)
+    // - signlePrecision = true halves memory usage and make x86 limit to 120M points
     // - in x64 mode limit can be up to maximum array size (2G points) with special solution and 64 GB RAM (not tested)
     // - if source array is changed UpdateTrees() must be called
+    // - source array can be change by call updateData(), updating by ranges much faster.
     public class PlottableSignalConst : PlottableSignal
     {
         // using 2 x signal memory in best case: ys.Length is Pow2 
         // using 4 x signal memory in worst case: ys.Length is (Pow2 +1);        
         double[] TreeMin;
         double[] TreeMax;
+        // signlePrecision Trees, halves additional memory usage
         float[] TreeMinF;
         float[] TreeMaxF;
         private int n = 0; // size of each Tree

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -344,12 +344,6 @@ namespace ScottPlot
 
             lowestValue = double.MaxValue;
             highestValue = double.MinValue;
-            if (l > r)
-            {
-                int temp = r;
-                r = l;
-                l = temp;
-            }
             if (l == r)
             {
                 lowestValue = ys[l];

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -25,8 +25,9 @@ namespace ScottPlot
         private int n = 0; // size of each Tree
         public bool TreesReady = false;
         private bool singlePrecision = false; // float type for trees, which uses half memory
-        public PlottableSignalConst(double[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel) : base(ys, sampleRate, xOffset, yOffset, color, lineWidth, markerSize, label, useParallel)
+        public PlottableSignalConst(double[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel, bool singlePrecision = false) : base(ys, sampleRate, xOffset, yOffset, color, lineWidth, markerSize, label, useParallel)
         {
+            this.singlePrecision = singlePrecision;
             if (useParallel)
                 UpdateTreesInBackground();
             else

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -33,100 +33,207 @@ namespace ScottPlot
         public void updateData(int index, double newValue)
         {
             ys[index] = newValue;
-            // Update Tree, can be optimized            
-            if (index == ys.Length - 1) // last elem haven't pair
+            if (singlePrecision == false)
             {
-                TreeMin[n / 2 + index / 2] = ys[index];
-                TreeMax[n / 2 + index / 2] = ys[index];
+                // Update Tree, can be optimized            
+                if (index == ys.Length - 1) // last elem haven't pair
+                {
+                    TreeMin[n / 2 + index / 2] = ys[index];
+                    TreeMax[n / 2 + index / 2] = ys[index];
+                }
+                else if (index % 2 == 0) // even elem have right pair
+                {
+                    TreeMin[n / 2 + index / 2] = Math.Min(ys[index], ys[index + 1]);
+                    TreeMax[n / 2 + index / 2] = Math.Max(ys[index], ys[index + 1]);
+                }
+                else // odd elem have left pair
+                {
+                    TreeMin[n / 2 + index / 2] = Math.Min(ys[index], ys[index - 1]);
+                    TreeMax[n / 2 + index / 2] = Math.Max(ys[index], ys[index - 1]);
+                }
             }
-            else if (index % 2 == 0) // even elem have right pair
+            else
             {
-                TreeMin[n / 2 + index / 2] = Math.Min(ys[index], ys[index + 1]);
-                TreeMax[n / 2 + index / 2] = Math.Max(ys[index], ys[index + 1]);
-            }
-            else // odd elem have left pair
-            {
-                TreeMin[n / 2 + index / 2] = Math.Min(ys[index], ys[index - 1]);
-                TreeMax[n / 2 + index / 2] = Math.Max(ys[index], ys[index - 1]);
+                if (index == ys.Length - 1) // last elem haven't pair
+                {
+                    TreeMinF[n / 2 + index / 2] = (float)ys[index];
+                    TreeMaxF[n / 2 + index / 2] = (float)ys[index];
+                }
+                else if (index % 2 == 0) // even elem have right pair
+                {
+                    TreeMinF[n / 2 + index / 2] = (float)Math.Min(ys[index], ys[index + 1]);
+                    TreeMaxF[n / 2 + index / 2] = (float)Math.Max(ys[index], ys[index + 1]);
+                }
+                else // odd elem have left pair
+                {
+                    TreeMinF[n / 2 + index / 2] = (float)Math.Min(ys[index], ys[index - 1]);
+                    TreeMaxF[n / 2 + index / 2] = (float)Math.Max(ys[index], ys[index - 1]);
+                }
             }
 
-            double candidate;
-            for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+            if (singlePrecision == false)
             {
-                candidate = Math.Min(TreeMin[i * 2], TreeMin[i * 2 + 1]);
-                if (TreeMin[i] == candidate) // if node same then new value don't need to recalc all upper
-                    break;
-                TreeMin[i] = candidate;
+                double candidate;
+                for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+                {
+                    candidate = Math.Min(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+                    if (TreeMin[i] == candidate) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMin[i] = candidate;
+                }
+                for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+                {
+                    candidate = Math.Max(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+                    if (TreeMax[i] == candidate) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMax[i] = candidate;
+                }
             }
-            for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+            else
             {
-                candidate = Math.Max(TreeMax[i * 2], TreeMax[i * 2 + 1]);
-                if (TreeMax[i] == candidate) // if node same then new value don't need to recalc all upper
-                    break;
-                TreeMax[i] = candidate;
+                float candidate;
+                for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+                {
+                    candidate = Math.Min(TreeMinF[i * 2], TreeMinF[i * 2 + 1]);
+                    if (TreeMinF[i] == candidate) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMinF[i] = candidate;
+                }
+                for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+                {
+                    candidate = Math.Max(TreeMaxF[i * 2], TreeMaxF[i * 2 + 1]);
+                    if (TreeMaxF[i] == candidate) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMaxF[i] = candidate;
+                }
             }
         }
 
-        public void updateData(int from, int to, double[] newData, int fromData = 0)
-        {            
+        public void updateData(int from, int to, double[] newData, int fromData = 0) // RangeUpdate
+        {
             //update source signal
             for (int i = from; i < to; i++)
             {
                 ys[i] = newData[i - from + fromData];
             }
-            
-            for (int i = n / 2 + from / 2; i < n / 2 + to / 2; i++)
+            if (singlePrecision == false)
             {
-                TreeMin[i] = Math.Min(ys[i * 2 - n], ys[i * 2 + 1 - n]);
-                TreeMax[i] = Math.Max(ys[i * 2 - n], ys[i * 2 + 1 - n]);
+                for (int i = n / 2 + from / 2; i < n / 2 + to / 2; i++)
+                {
+                    TreeMin[i] = Math.Min(ys[i * 2 - n], ys[i * 2 + 1 - n]);
+                    TreeMax[i] = Math.Max(ys[i * 2 - n], ys[i * 2 + 1 - n]);
+                }
+                if (to == ys.Length) // last elem haven't pair
+                {
+                    TreeMin[n / 2 + to / 2] = ys[to - 1];
+                    TreeMax[n / 2 + to / 2] = ys[to - 1];
+                }
+                else if (to % 2 == 1) //last elem even(to-1) and not last
+                {
+                    TreeMin[n / 2 + to / 2] = Math.Min(ys[to - 1], ys[to]);
+                    TreeMax[n / 2 + to / 2] = Math.Max(ys[to - 1], ys[to]);
+                }
             }
-            if (to == ys.Length) // last elem haven't pair
+            else
             {
-                TreeMin[n / 2 + to / 2] = ys[to - 1];
-                TreeMax[n / 2 + to / 2] = ys[to - 1];
+
+                for (int i = n / 2 + from / 2; i < n / 2 + to / 2; i++)
+                {
+                    TreeMinF[i] = (float)Math.Min(ys[i * 2 - n], ys[i * 2 + 1 - n]);
+                    TreeMaxF[i] = (float)Math.Max(ys[i * 2 - n], ys[i * 2 + 1 - n]);
+                }
+                if (to == ys.Length) // last elem haven't pair
+                {
+                    TreeMinF[n / 2 + to / 2] = (float)ys[to - 1];
+                    TreeMaxF[n / 2 + to / 2] = (float)ys[to - 1];
+                }
+                else if (to % 2 == 1) //last elem even(to-1) and not last
+                {
+                    TreeMinF[n / 2 + to / 2] = (float)Math.Min(ys[to - 1], ys[to]);
+                    TreeMaxF[n / 2 + to / 2] = (float)Math.Max(ys[to - 1], ys[to]);
+                }
             }
-            else if (to % 2 == 1) //last elem even(to-1) and not last
-            {
-                TreeMin[n / 2 + to / 2] = Math.Min(ys[to - 1], ys[to]);
-                TreeMax[n / 2 + to / 2] = Math.Max(ys[to - 1], ys[to]);
-            }
+
             from = (n / 2 + from / 2) / 2;
             to = (n / 2 + to / 2) / 2;
-            double candidate;
-            while (from != 0) // up to root elem, that is [1], [0] - is free elem
-            {
-                if (from != to)
-                {
-                    for (int i = from; i <= to; i++) // Recalc all level nodes in range 
-                    {
-                        TreeMin[i] = Math.Min(TreeMin[i * 2], TreeMin[i * 2 + 1]);
-                        TreeMax[i] = Math.Max(TreeMax[i * 2], TreeMax[i * 2 + 1]);
-                    }
-                }
-                else
-                {
-                    // left == rigth, so no need more from to loop
-                    for (int i = from; i > 0; i /= 2) // up to root node
-                    {
-                        candidate = Math.Min(TreeMin[i * 2], TreeMin[i * 2 + 1]);
-                        if (TreeMin[i] == candidate) // if node same then new value don't need to recalc all upper
-                            break;
-                        TreeMin[i] = candidate;
-                    }
 
-                    for (int i = from; i > 0; i /= 2) // up to root node
+            if (singlePrecision == false)
+            {
+                double candidate;
+                while (from != 0) // up to root elem, that is [1], [0] - is free elem
+                {
+                    if (from != to)
                     {
-                        candidate = Math.Max(TreeMax[i * 2], TreeMax[i * 2 + 1]);
-                        if (TreeMax[i] == candidate) // if node same then new value don't need to recalc all upper
-                            break;
-                        TreeMax[i] = candidate;
+                        for (int i = from; i <= to; i++) // Recalc all level nodes in range 
+                        {
+                            TreeMin[i] = Math.Min(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+                            TreeMax[i] = Math.Max(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+                        }
                     }
-                    // all work done exit while loop
-                    break;
+                    else
+                    {
+                        // left == rigth, so no need more from to loop
+                        for (int i = from; i > 0; i /= 2) // up to root node
+                        {
+                            candidate = Math.Min(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+                            if (TreeMin[i] == candidate) // if node same then new value don't need to recalc all upper
+                                break;
+                            TreeMin[i] = candidate;
+                        }
+
+                        for (int i = from; i > 0; i /= 2) // up to root node
+                        {
+                            candidate = Math.Max(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+                            if (TreeMax[i] == candidate) // if node same then new value don't need to recalc all upper
+                                break;
+                            TreeMax[i] = candidate;
+                        }
+                        // all work done exit while loop
+                        break;
+                    }
+                    // level up
+                    from = from / 2;
+                    to = to / 2;
                 }
-                // level up
-                from = from / 2;
-                to = to / 2;
+            }
+            else
+            {
+                float candidate;
+                while (from != 0) // up to root elem, that is [1], [0] - is free elem
+                {
+                    if (from != to)
+                    {
+                        for (int i = from; i <= to; i++) // Recalc all level nodes in range 
+                        {
+                            TreeMinF[i] = Math.Min(TreeMinF[i * 2], TreeMinF[i * 2 + 1]);
+                            TreeMaxF[i] = Math.Max(TreeMaxF[i * 2], TreeMaxF[i * 2 + 1]);
+                        }
+                    }
+                    else
+                    {
+                        // left == rigth, so no need more from to loop
+                        for (int i = from; i > 0; i /= 2) // up to root node
+                        {
+                            candidate = Math.Min(TreeMinF[i * 2], TreeMinF[i * 2 + 1]);
+                            if (TreeMinF[i] == candidate) // if node same then new value don't need to recalc all upper
+                                break;
+                            TreeMinF[i] = candidate;
+                        }
+
+                        for (int i = from; i > 0; i /= 2) // up to root node
+                        {
+                            candidate = Math.Max(TreeMaxF[i * 2], TreeMaxF[i * 2 + 1]);
+                            if (TreeMaxF[i] == candidate) // if node same then new value don't need to recalc all upper
+                                break;
+                            TreeMaxF[i] = candidate;
+                        }
+                        // all work done exit while loop
+                        break;
+                    }
+                    // level up
+                    from = from / 2;
+                    to = to / 2;
+                }
             }
         }
 


### PR DESCRIPTION
With singlePrecision=true SignalConst allocate and use float[] Trees. That halves memory usage, without visible changes. singlePrecision = false by default.
Additional maked small improvments on SignalConst Class.
This PR makes a lot of code duplicates in SignalConst class. I don't see another way to make it.