### PR TITLE
Make PlottableSignalConst generic

### DIFF
--- a/demos/src/plottable-const/Form1.cs
+++ b/demos/src/plottable-const/Form1.cs
@@ -13,7 +13,7 @@ namespace plottable_const
 {
     public partial class Form1 : Form
     {
-        ScottPlot.PlottableSignal<double> signal;
+        ScottPlot.PlottableSignal<float> signal;
         Random rand = new Random();
         double[] data;
         bool busy = false;
@@ -26,7 +26,7 @@ namespace plottable_const
         private void Form1_Load(object sender, EventArgs e)
         {
             data = ScottPlot.DataGen.RandomWalk(rand, 10_000_000);
-            signal = formsPlot1.plt.PlotSignal(data);
+            signal = formsPlot1.plt.PlotSignal(data.Select(x=>(float)x).ToArray());
             formsPlot1.plt.Benchmark();
             formsPlot1.Render();
         }
@@ -62,7 +62,7 @@ namespace plottable_const
             // run plot data updates at max speed in background thread                
             Task.Run(() =>
             {
-                if (signal is ScottPlot.PlottableSignalConst)
+                /*if (signal is ScottPlot.PlottableSignalConst)
                 {
                     var signalConst = signal as ScottPlot.PlottableSignalConst;
                     signalConst.updateData(0, rand.NextDouble() * 10 - 5);
@@ -99,6 +99,7 @@ namespace plottable_const
                     formsPlot1.Render();
                     btnUpdateData.Enabled = true;
                 }));
+               */ 
             });
         }
     }

--- a/demos/src/plottable-const/Form1.cs
+++ b/demos/src/plottable-const/Form1.cs
@@ -26,7 +26,7 @@ namespace plottable_const
         private void Form1_Load(object sender, EventArgs e)
         {
             data = ScottPlot.DataGen.RandomWalk(rand, 10_000_000);
-            signal = formsPlot1.plt.PlotSignal(data.Select(x=>(float)x).ToArray());
+            signal = formsPlot1.plt.PlotSignalConst(data.Select(x=>(float)x).ToArray());
             formsPlot1.plt.Benchmark();
             formsPlot1.Render();
         }

--- a/demos/src/plottable-const/Form1.cs
+++ b/demos/src/plottable-const/Form1.cs
@@ -13,7 +13,7 @@ namespace plottable_const
 {
     public partial class Form1 : Form
     {
-        ScottPlot.PlottableSignal<float> signal;
+        ScottPlot.Plottable signal;
         Random rand = new Random();
         double[] data;
         bool busy = false;
@@ -26,7 +26,8 @@ namespace plottable_const
         private void Form1_Load(object sender, EventArgs e)
         {
             data = ScottPlot.DataGen.RandomWalk(rand, 10_000_000);
-            signal = formsPlot1.plt.PlotSignalConst(data.Select(x=>(float)x).ToArray());
+            signal = formsPlot1.plt.PlotSignalConst(data);
+            formsPlot1.plt.PlotSignalConst(data.Select(x=>(int)x).ToArray());
             formsPlot1.plt.Benchmark();
             formsPlot1.Render();
         }
@@ -62,9 +63,9 @@ namespace plottable_const
             // run plot data updates at max speed in background thread                
             Task.Run(() =>
             {
-                /*if (signal is ScottPlot.PlottableSignalConst)
+                if (signal is ScottPlot.PlottableSignalConst<double>)
                 {
-                    var signalConst = signal as ScottPlot.PlottableSignalConst;
+                    var signalConst = signal as ScottPlot.PlottableSignalConst<double>;
                     signalConst.updateData(0, rand.NextDouble() * 10 - 5);
                     if (updateRangeSize < 1)
                     {
@@ -98,8 +99,7 @@ namespace plottable_const
                         Thread.Sleep(100);
                     formsPlot1.Render();
                     btnUpdateData.Enabled = true;
-                }));
-               */ 
+                }));                
             });
         }
     }

--- a/demos/src/plottable-const/Form1.cs
+++ b/demos/src/plottable-const/Form1.cs
@@ -13,7 +13,7 @@ namespace plottable_const
 {
     public partial class Form1 : Form
     {
-        ScottPlot.PlottableSignal signal;
+        ScottPlot.PlottableSignal<double> signal;
         Random rand = new Random();
         double[] data;
         bool busy = false;
@@ -26,7 +26,7 @@ namespace plottable_const
         private void Form1_Load(object sender, EventArgs e)
         {
             data = ScottPlot.DataGen.RandomWalk(rand, 10_000_000);
-            signal = formsPlot1.plt.PlotSignalConst(data);
+            signal = formsPlot1.plt.PlotSignal(data);
             formsPlot1.plt.Benchmark();
             formsPlot1.Render();
         }

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -369,8 +369,7 @@ namespace ScottPlot
             Color? color = null,
             double lineWidth = 1,
             double markerSize = 5,
-            string label = null,
-            bool singlePrecision = false
+            string label = null
             ) where T: struct, IComparable
         {
             if (color == null)
@@ -385,8 +384,7 @@ namespace ScottPlot
                 lineWidth: lineWidth,
                 markerSize: markerSize,
                 label: label,
-                useParallel: settings.useParallel,
-                singlePrecision: singlePrecision
+                useParallel: settings.useParallel
                 );
 
             settings.plottables.Add(signal);

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -331,8 +331,8 @@ namespace ScottPlot
             return stepPlot;
         }
 
-        public PlottableSignal<double> PlotSignal(
-            double[] ys,
+        public PlottableSignal<T> PlotSignal<T>(
+            T[] ys,
             double sampleRate = 1,
             double xOffset = 0,
             double yOffset = 0,
@@ -345,7 +345,7 @@ namespace ScottPlot
             if (color == null)
                 color = settings.GetNextColor();
 
-            PlottableSignal<double> signal = new PlottableSignal<double>(
+            PlottableSignal<T> signal = new PlottableSignal<T>(
                 ys: ys,
                 sampleRate: sampleRate,
                 xOffset: xOffset,

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -331,8 +331,8 @@ namespace ScottPlot
             return stepPlot;
         }
 
-        public PlottableSignal<T> PlotSignal<T>(
-            T[] ys,
+        public PlottableSignal PlotSignal(
+            double[] ys,
             double sampleRate = 1,
             double xOffset = 0,
             double yOffset = 0,
@@ -340,12 +340,12 @@ namespace ScottPlot
             double lineWidth = 1,
             double markerSize = 5,
             string label = null
-            ) where T: struct, IComparable
+            )
         {
             if (color == null)
                 color = settings.GetNextColor();
 
-            PlottableSignal<T> signal = new PlottableSignal<T>(
+            PlottableSignal signal = new PlottableSignal(
                 ys: ys,
                 sampleRate: sampleRate,
                 xOffset: xOffset,

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -331,7 +331,7 @@ namespace ScottPlot
             return stepPlot;
         }
 
-        public PlottableSignal PlotSignal(
+        public PlottableSignal<double> PlotSignal(
             double[] ys,
             double sampleRate = 1,
             double xOffset = 0,
@@ -345,7 +345,7 @@ namespace ScottPlot
             if (color == null)
                 color = settings.GetNextColor();
 
-            PlottableSignal signal = new PlottableSignal(
+            PlottableSignal<double> signal = new PlottableSignal<double>(
                 ys: ys,
                 sampleRate: sampleRate,
                 xOffset: xOffset,

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -340,7 +340,7 @@ namespace ScottPlot
             double lineWidth = 1,
             double markerSize = 5,
             string label = null
-            )
+            ) where T: struct, IComparable
         {
             if (color == null)
                 color = settings.GetNextColor();
@@ -371,7 +371,7 @@ namespace ScottPlot
             double markerSize = 5,
             string label = null,
             bool singlePrecision = false
-            )
+            ) where T: struct, IComparable
         {
             if (color == null)
                 color = settings.GetNextColor();

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -361,8 +361,8 @@ namespace ScottPlot
             return signal;
         }
 
-        public PlottableSignalConst PlotSignalConst(
-            double[] ys,
+        public PlottableSignalConst<T> PlotSignalConst<T>(
+            T[] ys,
             double sampleRate = 1,
             double xOffset = 0,
             double yOffset = 0,
@@ -376,7 +376,7 @@ namespace ScottPlot
             if (color == null)
                 color = settings.GetNextColor();
 
-            PlottableSignalConst signal = new PlottableSignalConst(
+            PlottableSignalConst<T> signal = new PlottableSignalConst<T>(
                 ys: ys,
                 sampleRate: sampleRate,
                 xOffset: xOffset,

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -455,9 +455,9 @@ namespace ScottPlot
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableScatter && scatters)
                     indicesToDelete.Add(i);
-                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignal<>))                
+                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignal<>) && signals)                
                     indicesToDelete.Add(i);
-                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignalConst<>))
+                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignalConst<>) && signals)
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableText && text)
                     indicesToDelete.Add(i);

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -457,7 +457,7 @@ namespace ScottPlot
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableSignal && signals)                
                     indicesToDelete.Add(i);
-                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignalConst<>) && signals)
+                else if (plottables[i].GetType().IsGenericType && plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignalConst<>) && signals)
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableText && text)
                     indicesToDelete.Add(i);

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -455,7 +455,7 @@ namespace ScottPlot
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableScatter && scatters)
                     indicesToDelete.Add(i);
-                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignal<>) && signals)                
+                else if (plottables[i] is PlottableSignal && signals)                
                     indicesToDelete.Add(i);
                 else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignalConst<>) && signals)
                     indicesToDelete.Add(i);

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -455,7 +455,7 @@ namespace ScottPlot
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableScatter && scatters)
                     indicesToDelete.Add(i);
-                else if (plottables[i] is PlottableSignal && signals)
+                else if (plottables[i] is PlottableSignal<double> && signals)
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableText && text)
                     indicesToDelete.Add(i);

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -455,7 +455,7 @@ namespace ScottPlot
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableScatter && scatters)
                     indicesToDelete.Add(i);
-                else if (plottables[i] is PlottableSignal<double> && signals)
+                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignal<>))                
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableText && text)
                     indicesToDelete.Add(i);

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -457,6 +457,8 @@ namespace ScottPlot
                     indicesToDelete.Add(i);
                 else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignal<>))                
                     indicesToDelete.Add(i);
+                else if (plottables[i].GetType().GetGenericTypeDefinition() == typeof(PlottableSignalConst<>))
+                    indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableText && text)
                     indicesToDelete.Add(i);
                 else if (plottables[i] is PlottableBar && bar)

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -7,7 +7,7 @@ using System.Drawing;
 
 namespace ScottPlot
 {
-    public class PlottableSignal<T> : Plottable where T : struct, IComparable<T>
+    public class PlottableSignal<T> : Plottable
     {
         public T[] ys;
         public double sampleRate;
@@ -54,8 +54,8 @@ namespace ScottPlot
             double[] limits = new double[4];
             limits[0] = 0 + xOffset;
             limits[1] = samplePeriod * ys.Length + xOffset;
-            limits[2] = (double)(object)ys.Min() + yOffset;
-            limits[3] = (double)(object)ys.Max() + yOffset;
+            limits[2] = Convert.ToDouble(ys.Min()) + yOffset;
+            limits[3] = Convert.ToDouble(ys.Max()) + yOffset;
             return limits;
         }
 
@@ -177,20 +177,38 @@ namespace ScottPlot
             if (linePoints.Count > 0)
                 settings.gfxData.DrawLines(pen, linePoints.ToArray());
         }
-
+        
         protected virtual void MinMaxRangeQuery(int index1, int index2, out double lowestValue, out double highestValue)
         {
-            T lowestValueT = ys[index1];
-            T highestValueT = ys[index1];
-            for (int i = index1; i < index2; i++)
+            double[] dArr = (ys as double[]);
+            float[] fArr = (ys as float[]);
+            if (dArr != null)
             {
-                if (ys[i].CompareTo(lowestValueT) < 0)
-                    lowestValueT = ys[i];
-                if (ys[i].CompareTo(highestValueT) > 0)
-                    highestValueT = ys[i];
+                
+                lowestValue = dArr[index1];
+                highestValue = dArr[index1];
+                for (int i = index1; i < index2; i++)
+                {
+                    if (dArr[i] < lowestValue)
+                        lowestValue = dArr[i];
+                    if (dArr[i] > highestValue)
+                        highestValue = dArr[i];
+                }
             }
-            lowestValue = (double)(object)lowestValueT;
-            highestValue = (double)(object)highestValueT;
+            else if (fArr != null)
+            {
+                lowestValue = fArr[index1];
+                highestValue = fArr[index1];
+                for (int i = index1; i < index2; i++)
+                {
+                    if (fArr[i] < lowestValue)
+                        lowestValue = fArr[i];
+                    if (fArr[i] > highestValue)
+                        highestValue = fArr[i];
+                }
+            }
+            else
+                throw new ArgumentException("Unsuported array type, use double[] or float[] only");            
         }
 
         public override void Render(Settings settings)
@@ -205,8 +223,8 @@ namespace ScottPlot
             int visiblePointCount = visibleIndex2 - visibleIndex1;
             double pointsPerPixelColumn = visiblePointCount / settings.dataSize.Width;
 
-            PointF firstPoint = settings.GetPixel(xOffset, (double)(object)ys.First() + yOffset);
-            PointF lastPoint = settings.GetPixel(samplePeriod * (ys.Length - 1) + xOffset, (double)(object)ys.Last() + yOffset);
+            PointF firstPoint = settings.GetPixel(xOffset, Convert.ToDouble(ys.First()) + yOffset);
+            PointF lastPoint = settings.GetPixel(samplePeriod * (ys.Length - 1) + xOffset, Convert.ToDouble(ys.Last()) + yOffset);
             double dataWidthPx = lastPoint.X - firstPoint.X;
 
             // use different rendering methods based on how dense the data is on screen

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -78,7 +78,7 @@ namespace ScottPlot
             if (visibleIndex1 < 0)
                 visibleIndex1 = 0;
             for (int i = visibleIndex1; i <= visibleIndex2 + 1; i++)
-                linePoints.Add(settings.GetPixel(samplePeriod * i + xOffset, (double)(object)ys[i] + yOffset));
+                linePoints.Add(settings.GetPixel(samplePeriod * i + xOffset, Convert.ToDouble(ys[i]) + yOffset));
 
             if (linePoints.Count > 1)
             {

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -7,9 +7,9 @@ using System.Drawing;
 
 namespace ScottPlot
 {
-    public class PlottableSignal : Plottable
+    public class PlottableSignal<T> : Plottable where T : struct, IComparable<T>
     {
-        public double[] ys;
+        public T[] ys;
         public double sampleRate;
         public double samplePeriod;
         public float markerSize;
@@ -18,7 +18,7 @@ namespace ScottPlot
         public Pen pen;
         public Brush brush;
 
-        public PlottableSignal(double[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel)
+        public PlottableSignal(T[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel)
         {
 
             if (ys == null)
@@ -54,8 +54,8 @@ namespace ScottPlot
             double[] limits = new double[4];
             limits[0] = 0 + xOffset;
             limits[1] = samplePeriod * ys.Length + xOffset;
-            limits[2] = ys.Min() + yOffset;
-            limits[3] = ys.Max() + yOffset;
+            limits[2] = (double)(object)ys.Min() + yOffset;
+            limits[3] = (double)(object)ys.Max() + yOffset;
             return limits;
         }
 
@@ -63,8 +63,8 @@ namespace ScottPlot
         {
             // this function is for when the graph is zoomed so far out its entire display is a single vertical pixel column
 
-            PointF point1 = settings.GetPixel(xOffset, (float)ys.Min() + yOffset);
-            PointF point2 = settings.GetPixel(xOffset, (float)ys.Max() + yOffset);
+            PointF point1 = settings.GetPixel(xOffset, (float)(object)ys.Min() + yOffset);
+            PointF point2 = settings.GetPixel(xOffset, (float)(object)ys.Max() + yOffset);
             settings.gfxData.DrawLine(pen, point1, point2);
         }
 
@@ -78,7 +78,7 @@ namespace ScottPlot
             if (visibleIndex1 < 0)
                 visibleIndex1 = 0;
             for (int i = visibleIndex1; i <= visibleIndex2 + 1; i++)
-                linePoints.Add(settings.GetPixel(samplePeriod * i + xOffset, ys[i] + yOffset));
+                linePoints.Add(settings.GetPixel(samplePeriod * i + xOffset, (double)(object)ys[i] + yOffset));
 
             if (linePoints.Count > 1)
             {
@@ -180,15 +180,17 @@ namespace ScottPlot
 
         protected virtual void MinMaxRangeQuery(int index1, int index2, out double lowestValue, out double highestValue)
         {
-            lowestValue = ys[index1];
-            highestValue = ys[index1];
+            T lowestValueT = ys[index1];
+            T highestValueT = ys[index1];
             for (int i = index1; i < index2; i++)
             {
-                if (ys[i] < lowestValue)
-                    lowestValue = ys[i];
-                if (ys[i] > highestValue)
-                    highestValue = ys[i];
+                if (ys[i].CompareTo(lowestValueT) < 0)
+                    lowestValueT = ys[i];
+                if (ys[i].CompareTo(highestValueT) > 0)
+                    highestValueT = ys[i];
             }
+            lowestValue = (double)(object)lowestValueT;
+            highestValue = (double)(object)highestValueT;
         }
 
         public override void Render(Settings settings)
@@ -203,8 +205,8 @@ namespace ScottPlot
             int visiblePointCount = visibleIndex2 - visibleIndex1;
             double pointsPerPixelColumn = visiblePointCount / settings.dataSize.Width;
 
-            PointF firstPoint = settings.GetPixel(xOffset, ys.First() + yOffset);
-            PointF lastPoint = settings.GetPixel(samplePeriod * (ys.Length - 1) + xOffset, ys.Last() + yOffset);
+            PointF firstPoint = settings.GetPixel(xOffset, (double)(object)ys.First() + yOffset);
+            PointF lastPoint = settings.GetPixel(samplePeriod * (ys.Length - 1) + xOffset, (double)(object)ys.Last() + yOffset);
             double dataWidthPx = lastPoint.X - firstPoint.X;
 
             // use different rendering methods based on how dense the data is on screen

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -84,9 +84,10 @@ namespace ScottPlot
         private void RenderSingleLine(Settings settings)
         {
             // this function is for when the graph is zoomed so far out its entire display is a single vertical pixel column
-
-            PointF point1 = settings.GetPixel(xOffset, Convert.ToDouble(ys.Min()) + yOffset);
-            PointF point2 = settings.GetPixel(xOffset, Convert.ToDouble(ys.Max()) + yOffset);
+            double ymax, ymin;
+            MinMaxRangeQuery(0, ys.Length - 1, out ymin, out ymax); // speed improvement then this called from SignalConst           
+            PointF point1 = settings.GetPixel(xOffset, ymin + yOffset);
+            PointF point2 = settings.GetPixel(xOffset, ymax + yOffset);
             settings.gfxData.DrawLine(pen, point1, point2);
         }
 
@@ -258,8 +259,8 @@ namespace ScottPlot
             int visiblePointCount = visibleIndex2 - visibleIndex1;
             double pointsPerPixelColumn = visiblePointCount / settings.dataSize.Width;
 
-            PointF firstPoint = settings.GetPixel(xOffset, Convert.ToDouble(ys.First()) + yOffset);
-            PointF lastPoint = settings.GetPixel(samplePeriod * (ys.Length - 1) + xOffset, Convert.ToDouble(ys.Last()) + yOffset);
+            PointF firstPoint = settings.GetPixel(xOffset, Convert.ToDouble(ys[0]) + yOffset);
+            PointF lastPoint = settings.GetPixel(samplePeriod * (ys.Length - 1) + xOffset, Convert.ToDouble(ys[ys.Length - 1]) + yOffset);
             double dataWidthPx = lastPoint.X - firstPoint.X;
 
             // use different rendering methods based on how dense the data is on screen

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -68,7 +68,7 @@ namespace ScottPlot
 
         public override string ToString()
         {
-            return $"PlottableSignal with {pointCount} points";
+            return $"PlottableSignal with {pointCount} points ({typeof(T).Name})";
         }
 
         public override double[] GetLimits()

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -85,8 +85,8 @@ namespace ScottPlot
         {
             // this function is for when the graph is zoomed so far out its entire display is a single vertical pixel column
 
-            PointF point1 = settings.GetPixel(xOffset, (float)(object)ys.Min() + yOffset);
-            PointF point2 = settings.GetPixel(xOffset, (float)(object)ys.Max() + yOffset);
+            PointF point1 = settings.GetPixel(xOffset, Convert.ToDouble(ys.Min()) + yOffset);
+            PointF point2 = settings.GetPixel(xOffset, Convert.ToDouble(ys.Max()) + yOffset);
             settings.gfxData.DrawLine(pen, point1, point2);
         }
 

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -7,7 +7,7 @@ using System.Drawing;
 
 namespace ScottPlot
 {
-    public class PlottableSignal<T> : Plottable
+    public class PlottableSignal<T> : Plottable where T : struct, IComparable
     {
         public T[] ys;
         public double sampleRate;

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -46,7 +46,7 @@ namespace ScottPlot
             MaxValue = Expression.Lambda<Func<T>>(bodyMaxValue).Compile();
             MinValue = Expression.Lambda<Func<T>>(bodyMinValue).Compile();
         }
-        public PlottableSignalConst(T[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel, bool singlePrecision = false) : base(ys, sampleRate, xOffset, yOffset, color, lineWidth, markerSize, label, useParallel)
+        public PlottableSignalConst(T[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel) : base(ys, sampleRate, xOffset, yOffset, color, lineWidth, markerSize, label, useParallel)
         {
             try // runtime check
             {               

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -299,7 +299,7 @@ namespace ScottPlot
 
         public override string ToString()
         {
-            return $"PlottableSignalConst with {pointCount} points, trees {(TreesReady ? "" : "not")} calculated";
+            return $"PlottableSignalConst with {pointCount} points ({typeof(T).Name}), trees {(TreesReady ? "" : "not")} calculated";
         }
     }
 }

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -9,7 +9,8 @@ namespace ScottPlot
 {
     // Variation of PlottableSignal that uses a segmented tree for faster min/max range queries
     // - frequent min/max lookups are a bottleneck displaying large signals
-    // - limited to 60M points (250M in x64 mode) due to memory (tree uses from 2X to 4X memory)
+    // - double[] limited to 60M points (250M in x64 mode) due to memory (tree uses from 2X to 4X memory)
+    // - smaller data types have higher points count limits
     // - in x64 mode limit can be up to maximum array size (2G points) with special solution and 64 GB RAM (not tested)
     // - if source array is changed UpdateTrees() must be called
     // - source array can be change by call updateData(), updating by ranges much faster.

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -13,7 +13,7 @@ namespace ScottPlot
     // - in x64 mode limit can be up to maximum array size (2G points) with special solution and 64 GB RAM (not tested)
     // - if source array is changed UpdateTrees() must be called
     // - source array can be change by call updateData(), updating by ranges much faster.
-    public class PlottableSignalConst : PlottableSignal
+    public class PlottableSignalConst : PlottableSignal<double>
     {
         // using 2 x signal memory in best case: ys.Length is Pow2 
         // using 4 x signal memory in worst case: ys.Length is (Pow2 +1);        

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace ScottPlot
@@ -14,10 +15,20 @@ namespace ScottPlot
     // - in x64 mode limit can be up to maximum array size (2G points) with special solution and 64 GB RAM (not tested)
     // - if source array is changed UpdateTrees() must be called
     // - source array can be change by call updateData(), updating by ranges much faster.
-    public class PlottableSignalConst<T> : PlottableSignal<T> where T : struct, IComparable
-    {
+    public class PlottableSignalConst<T> : Plottable where T : struct, IComparable
+    {    
+        // Any changes must be sync with PlottableSignal
+        public T[] ys;
+        public double sampleRate;
+        public double samplePeriod;
+        public float markerSize;
+        public double xOffset;
+        public double yOffset;
+        public Pen pen;
+        public Brush brush;
+
         // using 2 x signal memory in best case: ys.Length is Pow2 
-        // using 4 x signal memory in worst case: ys.Length is (Pow2 +1);        
+        // using 4 x signal memory in worst case: ys.Length is (Pow2 +1);
         T[] TreeMin;
         T[] TreeMax;
         private int n = 0; // size of each Tree
@@ -28,6 +39,8 @@ namespace ScottPlot
         private static Func<T, T, bool> EqualExp;
         private static Func<T> MaxValue;
         private static Func<T> MinValue;
+        private static Func<T, T, bool> LessThanExp;
+        private static Func<T, T, bool> GreaterThanExp;
 
         private void InitExp()
         {
@@ -39,15 +52,39 @@ namespace ScottPlot
             BinaryExpression bodyEqual = Expression.Equal(paramA, paramB);
             MemberExpression bodyMaxValue = Expression.MakeMemberAccess(null, typeof(T).GetField("MaxValue"));
             MemberExpression bodyMinValue = Expression.MakeMemberAccess(null, typeof(T).GetField("MinValue"));
+            BinaryExpression bodyLessThan = Expression.LessThan(paramA, paramB);
+            BinaryExpression bodyGreaterThan = Expression.GreaterThan(paramA, paramB);
             // compile it
             MinExp = Expression.Lambda<Func<T, T, T>>(bodyMin, paramA, paramB).Compile();
             MaxExp = Expression.Lambda<Func<T, T, T>>(bodyMax, paramA, paramB).Compile();
             EqualExp = Expression.Lambda<Func<T, T, bool>>(bodyEqual, paramA, paramB).Compile();
             MaxValue = Expression.Lambda<Func<T>>(bodyMaxValue).Compile();
             MinValue = Expression.Lambda<Func<T>>(bodyMinValue).Compile();
+            LessThanExp = Expression.Lambda<Func<T, T, bool>>(bodyLessThan, paramA, paramB).Compile();
+            GreaterThanExp = Expression.Lambda<Func<T, T, bool>>(bodyGreaterThan, paramA, paramB).Compile();
         }
-        public PlottableSignalConst(T[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel) : base(ys, sampleRate, xOffset, yOffset, color, lineWidth, markerSize, label, useParallel)
+        public PlottableSignalConst(T[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, bool useParallel)
         {
+            if (ys == null)
+                throw new Exception("Y data cannot be null");
+            this.ys = ys;
+            this.sampleRate = sampleRate;
+            this.samplePeriod = 1.0 / sampleRate;
+            this.markerSize = (float)markerSize;
+            this.xOffset = xOffset;
+            this.label = label;
+            this.color = color;
+            this.yOffset = yOffset;
+            this.useParallel = useParallel;
+            pointCount = ys.Length;
+            brush = new SolidBrush(color);
+            pen = new Pen(color, (float)lineWidth)
+            {
+                // this prevents sharp corners
+                StartCap = System.Drawing.Drawing2D.LineCap.Round,
+                EndCap = System.Drawing.Drawing2D.LineCap.Round,
+                LineJoin = System.Drawing.Drawing2D.LineJoin.Round
+            };
             try // runtime check
             {               
                 Convert.ToDouble(new T());
@@ -56,7 +93,7 @@ namespace ScottPlot
             {
                 throw new ArgumentOutOfRangeException("Unsupported data type, provide convertable to double data types");
             }
-            InitExp();
+            InitExp();         
             if (useParallel)
                 UpdateTreesInBackground();
             else
@@ -234,18 +271,30 @@ namespace ScottPlot
         }
 
         //  O(log(n)) for each range min/max query
-        protected override void MinMaxRangeQuery(int l, int r, out double lowestValue, out double highestValue)
+        protected void MinMaxRangeQuery(int l, int r, out double lowestValue, out double highestValue)
         {
+            T lowestValueT;
+            T highestValueT;
             // if the tree calculation isn't finished or if it crashed
             if (!TreesReady)
             {
                 // use the original (slower) min/max calculated method
-                base.MinMaxRangeQuery(l, r, out lowestValue, out highestValue);
+                lowestValueT = ys[l];
+                highestValueT = ys[l];
+                for (int i = l; i < r; i++)
+                {
+                    if (LessThanExp(ys[i], lowestValueT))
+                        lowestValueT = ys[i];
+                    if (GreaterThanExp(ys[i], highestValueT))
+                        highestValueT = ys[i];
+                }
+                lowestValue = Convert.ToDouble(lowestValueT);
+                highestValue = Convert.ToDouble(highestValueT);
                 return;
             }
 
-            T lowestValueT = MaxValue();
-            T highestValueT = MinValue();
+            lowestValueT = MaxValue();
+            highestValueT = MinValue();
             if (l == r)
             {
                 lowestValue = highestValue = Convert.ToDouble(ys[l]);
@@ -297,9 +346,170 @@ namespace ScottPlot
             return limits;
         }
 
+        private void RenderSingleLine(Settings settings)
+        {
+            // this function is for when the graph is zoomed so far out its entire display is a single vertical pixel column
+            double yMin, yMax;
+            MinMaxRangeQuery(0, ys.Length - 1, out yMin, out yMax);            
+            PointF point1 = settings.GetPixel(xOffset, yMin + yOffset);
+            PointF point2 = settings.GetPixel(xOffset, yMax + yOffset);
+            settings.gfxData.DrawLine(pen, point1, point2);
+        }
+
+        private void RenderLowDensity(Settings settings, int visibleIndex1, int visibleIndex2)
+        {
+            // this function is for when the graph is zoomed in so individual data points can be seen
+
+            List<PointF> linePoints = new List<PointF>(visibleIndex2 - visibleIndex1 + 2);
+            if (visibleIndex2 > ys.Length - 2)
+                visibleIndex2 = ys.Length - 2;
+            if (visibleIndex1 < 0)
+                visibleIndex1 = 0;
+            for (int i = visibleIndex1; i <= visibleIndex2 + 1; i++)
+                linePoints.Add(settings.GetPixel(samplePeriod * i + xOffset, Convert.ToDouble(ys[i]) + yOffset));
+
+            if (linePoints.Count > 1)
+            {
+                settings.gfxData.DrawLines(pen, linePoints.ToArray());
+                foreach (PointF point in linePoints)
+                    settings.gfxData.FillEllipse(brush, point.X - markerSize / 2, point.Y - markerSize / 2, markerSize, markerSize);
+            }
+        }
+
+        private void RenderHighDensityParallel(Settings settings, double offsetPoints, double columnPointCount)
+        {
+            int xPxStart = (int)Math.Ceiling((-1 - offsetPoints) / columnPointCount - 1);
+            int xPxEnd = (int)Math.Ceiling((ys.Length - offsetPoints) / columnPointCount);
+            xPxStart = Math.Max(0, xPxStart);
+            xPxEnd = Math.Min(settings.dataSize.Width, xPxEnd);
+            if (xPxStart >= xPxEnd)
+                return;
+            PointF[] linePoints = new PointF[(xPxEnd - xPxStart) * 2];
+            Parallel.For(xPxStart, xPxEnd, xPx =>
+            {
+                // determine data indexes for this pixel column
+                int index1 = (int)(offsetPoints + columnPointCount * xPx);
+                int index2 = (int)(offsetPoints + columnPointCount * (xPx + 1));
+
+                if (index1 < 0)
+                    index1 = 0;
+                if (index2 > ys.Length - 1)
+                    index2 = ys.Length - 1;
+
+                // get the min and max value for this column                
+                double lowestValue, highestValue;
+                MinMaxRangeQuery(index1, index2, out lowestValue, out highestValue);
+                float yPxHigh = settings.GetPixel(0, lowestValue + yOffset).Y;
+                float yPxLow = settings.GetPixel(0, highestValue + yOffset).Y;
+
+                linePoints[(xPx - xPxStart) * 2] = new PointF(xPx, yPxLow);
+                linePoints[(xPx - xPxStart) * 2 + 1] = new PointF(xPx, yPxHigh);
+            });
+
+            // adjust order of points to enhance anti-aliasing
+            PointF buf;
+            for (int i = 1; i < linePoints.Length / 2; i++)
+            {
+                if (linePoints[i * 2].Y >= linePoints[i * 2 - 1].Y)
+                {
+                    buf = linePoints[i * 2];
+                    linePoints[i * 2] = linePoints[i * 2 + 1];
+                    linePoints[i * 2 + 1] = buf;
+                }
+            }
+
+            settings.gfxData.DrawLines(pen, linePoints);
+        }
+
+        private void RenderHighDensity(Settings settings, double offsetPoints, double columnPointCount)
+        {
+            // this function is for when the graph is zoomed out so each pixel column represents the vertical span of multiple data points
+            int xPxStart = (int)Math.Ceiling((-1 - offsetPoints) / columnPointCount - 1);
+            int xPxEnd = (int)Math.Ceiling((ys.Length - offsetPoints) / columnPointCount);
+            xPxStart = Math.Max(0, xPxStart);
+            xPxEnd = Math.Min(settings.dataSize.Width, xPxEnd);
+            if (xPxStart >= xPxEnd)
+                return;
+            List<PointF> linePoints = new List<PointF>((xPxEnd - xPxStart) * 2 + 1);
+            for (int xPx = xPxStart; xPx < xPxEnd; xPx++)
+            {
+                // determine data indexes for this pixel column
+                int index1 = (int)(offsetPoints + columnPointCount * xPx);
+                int index2 = (int)(offsetPoints + columnPointCount * (xPx + 1));
+
+                if (index1 < 0)
+                    index1 = 0;
+                if (index2 > ys.Length - 1)
+                    index2 = ys.Length - 1;
+
+                // get the min and max value for this column                
+                double lowestValue, highestValue;                
+                MinMaxRangeQuery(index1, index2, out lowestValue, out highestValue);
+                float yPxHigh = settings.GetPixel(0, lowestValue + yOffset).Y;
+                float yPxLow = settings.GetPixel(0, highestValue + yOffset).Y;
+
+                // adjust order of points to enhance anti-aliasing
+                if ((linePoints.Count < 2) || (yPxLow < linePoints[linePoints.Count - 1].Y))
+                {
+                    linePoints.Add(new PointF(xPx, yPxLow));
+                    linePoints.Add(new PointF(xPx, yPxHigh));
+                }
+                else
+                {
+                    linePoints.Add(new PointF(xPx, yPxHigh));
+                    linePoints.Add(new PointF(xPx, yPxLow));
+                }
+            }
+
+            if (linePoints.Count > 0)
+                settings.gfxData.DrawLines(pen, linePoints.ToArray());
+        }
+
+        public override void Render(Settings settings)
+        {
+            double dataSpanUnits = ys.Length * samplePeriod;
+            double columnSpanUnits = settings.xAxisSpan / settings.dataSize.Width;
+            double columnPointCount = (columnSpanUnits / dataSpanUnits) * ys.Length;
+            double offsetUnits = settings.axis[0] - xOffset;
+            double offsetPoints = offsetUnits / samplePeriod;
+            int visibleIndex1 = (int)(offsetPoints);
+            int visibleIndex2 = (int)(offsetPoints + columnPointCount * (settings.dataSize.Width + 1));
+            int visiblePointCount = visibleIndex2 - visibleIndex1;
+            double pointsPerPixelColumn = visiblePointCount / settings.dataSize.Width;
+
+            PointF firstPoint = settings.GetPixel(xOffset, Convert.ToDouble(ys[0]) + yOffset);
+            PointF lastPoint = settings.GetPixel(samplePeriod * (ys.Length - 1) + xOffset, Convert.ToDouble(ys[ys.Length - 1]) + yOffset);
+            double dataWidthPx = lastPoint.X - firstPoint.X;
+
+            // use different rendering methods based on how dense the data is on screen
+            if (dataWidthPx <= 1)
+            {
+                RenderSingleLine(settings);
+            }
+            else if (pointsPerPixelColumn > 1)
+            {
+                if (useParallel)
+                    RenderHighDensityParallel(settings, offsetPoints, columnPointCount);
+                else
+                    RenderHighDensity(settings, offsetPoints, columnPointCount);
+            }
+            else
+            {
+                RenderLowDensity(settings, visibleIndex1, visibleIndex2);
+            }
+        }
+
         public override string ToString()
         {
             return $"PlottableSignalConst with {pointCount} points ({typeof(T).Name}), trees {(TreesReady ? "" : "not")} calculated";
+        }
+
+        public override void SaveCSV(string filePath)
+        {
+            StringBuilder csv = new StringBuilder();
+            for (int i = 0; i < ys.Length; i++)
+                csv.AppendFormat("{0}, {1}\n", xOffset + i * samplePeriod, Convert.ToDouble(ys[i]));
+            System.IO.File.WriteAllText(filePath, csv.ToString());
         }
     }
 }


### PR DESCRIPTION
Signal and SignalConst maked generic, thats allow plot different types of struct data types (float, int, byte etc). This types must be convertable to Double.
With generic data types all comparation calculation goes slower by 30-40%.
SignalConst overall render not visibly affected by this.
PlottableSignal Render slower by 10-20% for 10M points at high resolution chart. Posible improvement commented in MinMaxRangeQuery(), but it will give lots of code duplicates for all posible data types.