### PR TITLE
ScottPlotTests: add more tests

### DIFF
--- a/tests/ScottPlotTests/UnitTest1.cs
+++ b/tests/ScottPlotTests/UnitTest1.cs
@@ -31,7 +31,7 @@ namespace ScottPlotTests
         {
             {
                 var plt = new ScottPlot.Plot(1, 1);
-                string file = Path.GetTempPath() + "test.bmp";
+                string file = Path.GetRandomFileName() + ".bmp";
                 plt.SaveFig(file);
                 Bitmap bmp = new Bitmap(file);
                 Assert.AreEqual(bmp.Width, 1);
@@ -40,7 +40,7 @@ namespace ScottPlotTests
 
             {
                 var plt = new ScottPlot.Plot(1, 1);
-                string file = Path.GetTempPath() + "test.bmp";
+                string file = Path.GetRandomFileName() + ".bmp";
                 try
                 {
                     plt.SaveFig(file, renderFirst: false);

--- a/tests/ScottPlotTests/UnitTest1.cs
+++ b/tests/ScottPlotTests/UnitTest1.cs
@@ -33,18 +33,22 @@ namespace ScottPlotTests
                 var plt = new ScottPlot.Plot(1, 1);
                 string file = Path.GetTempPath() + "test.bmp";
                 plt.SaveFig(file);
-                Bitmap bmp = new Bitmap(file);
-                Assert.AreEqual(bmp.Width, 1);
-                Assert.AreEqual(bmp.Height, 1);
+                using (Bitmap bmp = new Bitmap(file))
+                {
+                    Assert.AreEqual(bmp.Width, 1);
+                    Assert.AreEqual(bmp.Height, 1);
+                }
             }
 
             {
                 var plt = new ScottPlot.Plot(1, 1);
                 string file = Path.GetTempPath() + "test.png";
                 plt.SaveFig(file, renderFirst: false);
-                Bitmap bmp = new Bitmap(file);
-                Assert.AreEqual(bmp.Width, 1);
-                Assert.AreEqual(bmp.Height, 1);
+                using (Bitmap bmp = new Bitmap(file))
+                {
+                    Assert.AreEqual(bmp.Width, 1);
+                    Assert.AreEqual(bmp.Height, 1);
+                }
             }
         }
     }

--- a/tests/ScottPlotTests/UnitTest1.cs
+++ b/tests/ScottPlotTests/UnitTest1.cs
@@ -31,7 +31,7 @@ namespace ScottPlotTests
         {
             {
                 var plt = new ScottPlot.Plot(1, 1);
-                string file = Path.GetRandomFileName() + ".bmp";
+                string file = Path.GetTempPath() + "test.bmp";
                 plt.SaveFig(file);
                 Bitmap bmp = new Bitmap(file);
                 Assert.AreEqual(bmp.Width, 1);
@@ -40,15 +40,11 @@ namespace ScottPlotTests
 
             {
                 var plt = new ScottPlot.Plot(1, 1);
-                string file = Path.GetRandomFileName() + ".bmp";
-                try
-                {
-                    plt.SaveFig(file, renderFirst: false);
-                }
-                catch (Exception ex)
-                {
-                    Assert.Fail("Expected no exception, but got: " + ex.Message);
-                }
+                string file = Path.GetTempPath() + "test.png";
+                plt.SaveFig(file, renderFirst: false);
+                Bitmap bmp = new Bitmap(file);
+                Assert.AreEqual(bmp.Width, 1);
+                Assert.AreEqual(bmp.Height, 1);
             }
         }
     }

--- a/tests/ScottPlotTests/UnitTest1.cs
+++ b/tests/ScottPlotTests/UnitTest1.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Drawing;
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ScottPlotTests
@@ -7,15 +9,47 @@ namespace ScottPlotTests
     public class UnitTest1
     {
         [TestMethod]
-        public void TestMethod1()
+        public void TestGetBitmap()
         {
-            var plt = new ScottPlot.Plot();
-            plt.PlotScatter(
-                xs: new double[] { 2, 4, 6 },
-                ys: new double[] { 4, 16, 36 }
-                );
-            System.Drawing.Bitmap bmp = plt.GetBitmap(); // force a render
-            Console.WriteLine(plt.GetHashCode()); // force a render too
+            {
+                var plt = new ScottPlot.Plot(1, 1);
+                Bitmap bmp = plt.GetBitmap();
+                Assert.AreEqual(bmp.Width, 1);
+                Assert.AreEqual(bmp.Height, 1);
+            }
+
+            {
+                var plt = new ScottPlot.Plot(1, 1);
+                Bitmap bmp = plt.GetBitmap(false, false);
+                Assert.AreEqual(bmp.Width, 1);
+                Assert.AreEqual(bmp.Height, 1);
+            }
+        }
+
+        [TestMethod]
+        public void TestSaveFig()
+        {
+            {
+                var plt = new ScottPlot.Plot(1, 1);
+                string file = Path.GetTempPath() + "test.bmp";
+                plt.SaveFig(file);
+                Bitmap bmp = new Bitmap(file);
+                Assert.AreEqual(bmp.Width, 1);
+                Assert.AreEqual(bmp.Height, 1);
+            }
+
+            {
+                var plt = new ScottPlot.Plot(1, 1);
+                string file = Path.GetTempPath() + "test.bmp";
+                try
+                {
+                    plt.SaveFig(file, renderFirst: false);
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail("Expected no exception, but got: " + ex.Message);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Caught an unexpected exception while saving figure without rendering first.   Saving an empty bitmap might be more appropriate.
