### PR TITLE
Alternative font select implementation

### DIFF
--- a/src/ScottPlot/Config/Fonts.cs
+++ b/src/ScottPlot/Config/Fonts.cs
@@ -28,8 +28,13 @@ namespace ScottPlot.Config
         /// </summary>
         public static string GetDefaultFontName()
         {
+            return GetDefaultFontName(FontFamily.Families.Select(font => font.Name.ToUpper()).ToArray());
+        }
+
+        public static string GetDefaultFontName(string[] installedFonts)
+        {
             string[] preferredFonts = { "Segoe UI", "DejaVu Sans" };
-            string[] installedFonts = FontFamily.Families.Select(font => font.Name.ToUpper()).ToArray();
+            //string[] installedFonts = FontFamily.Families.Select(font => font.Name.ToUpper()).ToArray();
 
             foreach (string preferredFont in preferredFonts)
                 if (installedFonts.Contains(preferredFont.ToUpper()))
@@ -37,5 +42,6 @@ namespace ScottPlot.Config
 
             return SystemFonts.DefaultFont.Name;
         }
+
     }
 }

--- a/src/ScottPlot/Config/Fonts.cs
+++ b/src/ScottPlot/Config/Fonts.cs
@@ -33,12 +33,13 @@ namespace ScottPlot.Config
 
         public static string GetDefaultFontName(string[] installedFonts)
         {
-            string[] preferredFonts = { "Segoe UI", "DejaVu Sans" };
-            //string[] installedFonts = FontFamily.Families.Select(font => font.Name.ToUpper()).ToArray();
+            string[] preferredFonts = { "Segoe UI", "DejaVu", "Sans" };
+            preferredFonts = preferredFonts.Select(f => f.ToUpper()).ToArray();
 
-            foreach (string preferredFont in preferredFonts)
-                if (installedFonts.Contains(preferredFont.ToUpper()))
-                    return preferredFont;
+            foreach (string prefferredFont in preferredFonts)
+                foreach (string installedFont in installedFonts)
+                    if (installedFont.ToUpper().Contains(prefferredFont))
+                        return installedFont;
 
             return SystemFonts.DefaultFont.Name;
         }

--- a/src/ScottPlot/Config/Fonts.cs
+++ b/src/ScottPlot/Config/Fonts.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 
 namespace ScottPlot.Config
 {
@@ -28,10 +26,15 @@ namespace ScottPlot.Config
         /// </summary>
         public static string GetDefaultFontName()
         {
-            return GetDefaultFontName(FontFamily.Families.Select(font => font.Name.ToUpper()).ToArray());
+            return GetDefaultFontName(FontFamily.Families.Select(font => font.Name));
         }
 
-        public static string GetDefaultFontName(string[] installedFonts)
+        /// <summary>
+        /// Returns the default ScottPlot font name (guaranteed to be installed on the system)
+        /// This method for ability to inject test set of fonts, main api method is GetDefaultFontName()
+        /// </summary>
+        /// <param name="installedFonts">strings containing installed fonts</param>
+        public static string GetDefaultFontName(IEnumerable<string> installedFonts)
         {
             string[] preferredFonts = { "Segoe UI", "DejaVu", "Sans" };
             preferredFonts = preferredFonts.Select(f => f.ToUpper()).ToArray();
@@ -43,6 +46,5 @@ namespace ScottPlot.Config
 
             return SystemFonts.DefaultFont.Name;
         }
-
     }
 }

--- a/src/ScottPlot/Config/TextLabel.cs
+++ b/src/ScottPlot/Config/TextLabel.cs
@@ -12,8 +12,8 @@ namespace ScottPlot.Config
 
         public TextLabel(Graphics gfx = null)
         {
-            this.gfx = gfx ?? Graphics.FromImage(new Bitmap(1, 1));
-
+            //this.gfx = gfx ?? Graphics.FromImage(new Bitmap(1, 1));
+            this.gfx = Graphics.FromHwnd(IntPtr.Zero);
             // set things which can't be instantiated at the class level
             color = Color.Black;
             colorBackground = Color.Magenta;

--- a/src/ScottPlot/Config/TextLabel.cs
+++ b/src/ScottPlot/Config/TextLabel.cs
@@ -12,8 +12,8 @@ namespace ScottPlot.Config
 
         public TextLabel(Graphics gfx = null)
         {
-            //this.gfx = gfx ?? Graphics.FromImage(new Bitmap(1, 1));
-            this.gfx = Graphics.FromHwnd(IntPtr.Zero);
+            this.gfx = gfx ?? Graphics.FromImage(new Bitmap(1, 1));
+
             // set things which can't be instantiated at the class level
             color = Color.Black;
             colorBackground = Color.Magenta;

--- a/tests/FontsTests.cs
+++ b/tests/FontsTests.cs
@@ -1,9 +1,5 @@
 ﻿using NUnit.Framework;
 using ScottPlot.Config;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ScottPlotTests
 {
@@ -14,19 +10,15 @@ namespace ScottPlotTests
         public void GetDefaultFontName_SegoeUIFontPresent_ReturnSegoeFont()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Segoe UI", "Comic Sans", "onemorefont" };
-            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
-
             string expected = "Segoe UI";
             string result = Fonts.GetDefaultFontName(presentFonts);
             Assert.AreEqual(expected, result);
         }
-        
+
         [Test]
         public void GetDefaultFontName_SegoeUIFontNotPresent_ReturnDifferentFont()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Comic Sans", "onemorefont" };
-            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
-
             string expected = "Segoe UI";
             string result = Fonts.GetDefaultFontName(presentFonts);
             Assert.AreNotEqual(expected, result);
@@ -36,8 +28,6 @@ namespace ScottPlotTests
         public void GetDefaultFontName_NoSegoeUIButSegoeUIBlackPresent_ReturnSegoeUIBlack()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Segoe UI Black", "Arial", "Comic Sans", "onemorefont" };
-            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
-
             string expected = "Segoe UI Black";
             string result = Fonts.GetDefaultFontName(presentFonts);
             Assert.AreEqual(expected, result);
@@ -46,9 +36,7 @@ namespace ScottPlotTests
         [Test]
         public void GetDefaultFontName_NoSegoeUIButSomeSansPresent_ReturnSansFont()
         {
-            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne","Arial", "Comic Sans", "onemorefont" };
-            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
-
+            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Comic Sans", "onemorefont" };
             string expected = "Comic Sans";
             string result = Fonts.GetDefaultFontName(presentFonts);
             Assert.AreEqual(expected, result);
@@ -57,13 +45,10 @@ namespace ScottPlotTests
         [Test]
         public void GetDefaultFontName_NoSegoeUIButSomeSansandDejavuPresent_ReturnDejavuFont()
         {
-            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne",  "Arial", "Comic Sans", "onemorefont", "Fictional Dejavu"};
-            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
-
+            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Comic Sans", "onemorefont", "Fictional Dejavu" };
             string expected = "Fictional Dejavu";
             string result = Fonts.GetDefaultFontName(presentFonts);
             Assert.AreEqual(expected, result);
         }
-
     }
 }

--- a/tests/FontsTests.cs
+++ b/tests/FontsTests.cs
@@ -1,0 +1,69 @@
+﻿using NUnit.Framework;
+using ScottPlot.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ScottPlotTests
+{
+    [TestFixture]
+    public class FontsTests
+    {
+        [Test]
+        public void GetDefaultFontName_SegoeUIFontPresent_ReturnSegoeFont()
+        {
+            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Segoe UI", "Comic Sans", "onemorefont" };
+            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+
+            string expected = "Segoe UI";
+            string result = Fonts.GetDefaultFontName(presentFonts);
+            Assert.AreEqual(expected, result);
+        }
+        
+        [Test]
+        public void GetDefaultFontName_SegoeUIFontNotPresent_ReturnDifferentFont()
+        {
+            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Comic Sans", "onemorefont" };
+            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+
+            string expected = "Segoe UI";
+            string result = Fonts.GetDefaultFontName(presentFonts);
+            Assert.AreNotEqual(expected, result);
+        }
+
+        [Test]
+        public void GetDefaultFontName_NoSegoeUIButSegoeUIBlackPresent_ReturnSegoeUIBlack()
+        {
+            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Segoe UI Black", "Arial", "Comic Sans", "onemorefont" };
+            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+
+            string expected = "Segoe UI Black";
+            string result = Fonts.GetDefaultFontName(presentFonts);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void GetDefaultFontName_NoSegoeUIButSomeSansPresent_ReturnSansFont()
+        {
+            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne","Arial", "Comic Sans", "onemorefont" };
+            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+
+            string expected = "Comic Sans";
+            string result = Fonts.GetDefaultFontName(presentFonts);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void GetDefaultFontName_NoSegoeUIButSomeSansandDejavuPresent_ReturnDejavuFont()
+        {
+            string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne",  "Arial", "Comic Sans", "onemorefont", "Fictional Dejavu"};
+            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+
+            string expected = "Fictional Dejavu";
+            string result = Fonts.GetDefaultFontName(presentFonts);
+            Assert.AreEqual(expected, result);
+        }
+
+    }
+}

--- a/tests/FontsTests.cs
+++ b/tests/FontsTests.cs
@@ -14,7 +14,7 @@ namespace ScottPlotTests
         public void GetDefaultFontName_SegoeUIFontPresent_ReturnSegoeFont()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Segoe UI", "Comic Sans", "onemorefont" };
-            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
 
             string expected = "Segoe UI";
             string result = Fonts.GetDefaultFontName(presentFonts);
@@ -25,7 +25,7 @@ namespace ScottPlotTests
         public void GetDefaultFontName_SegoeUIFontNotPresent_ReturnDifferentFont()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Arial", "Comic Sans", "onemorefont" };
-            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
 
             string expected = "Segoe UI";
             string result = Fonts.GetDefaultFontName(presentFonts);
@@ -36,7 +36,7 @@ namespace ScottPlotTests
         public void GetDefaultFontName_NoSegoeUIButSegoeUIBlackPresent_ReturnSegoeUIBlack()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne", "Segoe UI Black", "Arial", "Comic Sans", "onemorefont" };
-            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
 
             string expected = "Segoe UI Black";
             string result = Fonts.GetDefaultFontName(presentFonts);
@@ -47,7 +47,7 @@ namespace ScottPlotTests
         public void GetDefaultFontName_NoSegoeUIButSomeSansPresent_ReturnSansFont()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne","Arial", "Comic Sans", "onemorefont" };
-            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
 
             string expected = "Comic Sans";
             string result = Fonts.GetDefaultFontName(presentFonts);
@@ -58,7 +58,7 @@ namespace ScottPlotTests
         public void GetDefaultFontName_NoSegoeUIButSomeSansandDejavuPresent_ReturnDejavuFont()
         {
             string[] presentFonts = new string[] { "newFont ar", "SOME font", "AnotherOne",  "Arial", "Comic Sans", "onemorefont", "Fictional Dejavu"};
-            presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
+            //presentFonts = presentFonts.Select(x => x.ToUpper()).ToArray();
 
             string expected = "Fictional Dejavu";
             string result = Fonts.GetDefaultFontName(presentFonts);


### PR DESCRIPTION
Initially in PR #212 `GetDefaultFontName()` return installed font with name containing preferred words (not strictly). 
In final implementation, return installed font with name exactly as preferred.
This PR brings initial algoritm back, (with priority order).

Also this PR adds durty `public` `GetDefaultFontName(IEnumerable<string> installedFonts)`. This method needed to substitute  `static` `FontFamily.Families`. That allow  to write some unit tests. Can be collapsed back to single `GetDefaultFontName()`, but with loosing tests.

I actualy not see big benefits of this PR (anyway `GetDefaultFontName()` return existing `SystemFonts.DefaultFont.Name` in worst cases ). All the time i thinked "does it really need". So feel free to reject this PR.

If this PR will be rejected, small improvement can be applied to existing method:
~~`string[] installedFonts = FontFamily.Families.Select(font => font.Name.ToUpper()).ToArray();`~~
```c#
var installedFonts = FontFamily.Families.Select(font => font.Name.ToUpper());
```
No need ToArray() cast (this produce full enumeration). Foreach loop can be applied to `IEnumerable` and call `Select` lambda only for elements before return statement.
