### PR TITLE
Fixed issue with MatchAxis using vertical: false.

### DIFF
--- a/src/ScottPlot/Config/Axes.cs
+++ b/src/ScottPlot/Config/Axes.cs
@@ -17,7 +17,7 @@ namespace ScottPlot.Config
         {
             get
             {
-                return ((x.hasBeenSet) || (y.hasBeenSet));
+                return ((x.hasBeenSet) && (y.hasBeenSet));
             }
         }
 


### PR DESCRIPTION
Fixing issue #217. This was due to `Axes.hasBeenSet` uses OR instead of AND to compare, the correct line should be 
`return ((x.hasBeenSet) && (y.hasBeenSet));`

![keep_issue_multiplot](https://user-images.githubusercontent.com/9557072/72943130-389ae580-3d43-11ea-86ee-7c6978f589a8.png)
