### PR TITLE
Implement Settings.AxisAuto ExpandOnly params

### DIFF
--- a/src/ScottPlot/Config/Axes.cs
+++ b/src/ScottPlot/Config/Axes.cs
@@ -53,15 +53,21 @@ namespace ScottPlot.Config
             y.max = limits[3];
         }
 
-        public void Expand(double[] limits)
+        public void Expand(double[] limits, bool xExpandOnly = false, bool yExpandOnly = false)
         {
             if ((limits == null) || (limits.Length != 4))
                 throw new ArgumentException();
 
-            x.min = Math.Min(limits[0], x.min);
-            x.max = Math.Max(limits[1], x.max);
-            y.min = Math.Min(limits[2], y.min);
-            y.max = Math.Max(limits[3], y.max);
+            if (!yExpandOnly)
+            {
+                x.min = Math.Min(limits[0], x.min);
+                x.max = Math.Max(limits[1], x.max);
+            }
+            if (!xExpandOnly)
+            {
+                y.min = Math.Min(limits[2], y.min);
+                y.max = Math.Max(limits[3], y.max);
+            }
         }
 
         public void Zoom(double xFrac = 1, double yFrac = 1, PointF? zoomCenter = null)

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -148,7 +148,7 @@ namespace ScottPlot
             {
                 axes.Set(plottables2d[0].GetLimits());
                 foreach (Plottable plottable in plottables2d)
-                    axes.Expand(plottable.GetLimits());
+                    axes.Expand(plottable.GetLimits(), xExpandOnly, yExpandOnly);
             }
 
             // special case for 2d plots with no width

--- a/tests/AxesTests.cs
+++ b/tests/AxesTests.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using ScottPlot.Config;
+
+namespace ScottPlotTests
+{
+    [TestFixture]
+    public class AxesTests
+    {
+        [Test]
+        public void Expand_NoExpandParams_BothAxesChanged()
+        {
+            Axes axes = new Axes();
+            axes.Set(1, 2, 3, 4);
+            axes.Expand(new double[] { -11, 12, -13, 14 });
+
+            Assert.AreEqual(-11, axes.limits[0]);
+            Assert.AreEqual(12, axes.limits[1]);
+
+            Assert.AreEqual(-13, axes.limits[2]);
+            Assert.AreEqual(14, axes.limits[3]);
+        }
+        [Test]
+        public void Expand_xExpandOnly_ylimitsUnchanged()
+        {
+            Axes axes = new Axes();
+            axes.Set(1, 2, 3, 4);
+            axes.Expand(new double[] { -11, 12, -13, 14 }, xExpandOnly: true);
+            Assert.AreNotEqual(-13, axes.limits[2]);
+            Assert.AreNotEqual(14, axes.limits[3]);
+
+            Assert.AreNotEqual(1, axes.limits[0]);
+            Assert.AreNotEqual(2, axes.limits[1]);
+        }
+
+        [Test]
+        public void Expand_yExpandOnly_xlimitsUnchanged()
+        {
+            Axes axes = new Axes();
+            axes.Set(1, 2, 3, 4);
+            axes.Expand(new double[] { -11, 12, -13, 14 }, yExpandOnly: true);
+
+            Assert.AreEqual(1, axes.limits[0]);
+            Assert.AreEqual(2, axes.limits[1]);
+
+            Assert.AreEqual(-13, axes.limits[2]);
+            Assert.AreEqual(14, axes.limits[3]);
+        }
+    }
+}


### PR DESCRIPTION
Implement not used `Settings.AxisAuto()` `xExpandOnly` and `yExpandOnly` params.
