### PR TITLE
AxSpan Fix

### DIFF
--- a/src/ScottPlot/plottables/PlottableAxSpan.cs
+++ b/src/ScottPlot/plottables/PlottableAxSpan.cs
@@ -52,11 +52,19 @@ namespace ScottPlot
             {
                 topLeft = settings.GetPixel(position1, settings.axes.y.min);
                 lowerRight = settings.GetPixel(position2, settings.axes.y.max);
+                if (topLeft.X < 0)
+                    topLeft.X = 0;
+                if (lowerRight.X > settings.bmpData.Width)
+                    lowerRight.X = settings.bmpData.Width;
             }
             else
             {
                 topLeft = settings.GetPixel(settings.axes.x.min, position1);
                 lowerRight = settings.GetPixel(settings.axes.x.max, position2);
+                if (topLeft.Y > settings.bmpData.Height)
+                    topLeft.Y = settings.bmpData.Height;
+                if (lowerRight.Y < 0)
+                    lowerRight.Y = 0;
             }
 
             float width = lowerRight.X - topLeft.X + 1;


### PR DESCRIPTION
`PlottableAxSpan` produce strange effect, if deeply zoomed in on one of of `AxSpan` border . During paning, border start "dancing" around correct coordinate.

In `Render()` of axis span it try to draw huge rectangle, say from (-1000000, 0) to (574, 800). And this huge rectangle clipped to bitmap size by GDI, which possible produce this effect.

This PR manualy clip huge coordinates outside of `DataBitmap` and fix AxSpan border "dancing".