### PR TITLE
move event handlers into plottables

### DIFF
--- a/demos/WinForms/Demos/FormDraggableAxisLines.cs
+++ b/demos/WinForms/Demos/FormDraggableAxisLines.cs
@@ -37,7 +37,8 @@ namespace ScottPlotDemos
         private void BtnAddHline_Click(object sender, EventArgs e)
         {
             double position = rand.NextDouble() * 2 - 1;
-            formsPlot1.plt.PlotHLine(position, draggable: true, dragLimitLower: -1, dragLimitUpper: 1);
+            var hline = formsPlot1.plt.PlotHLine(position, draggable: true, dragLimitLower: -1, dragLimitUpper: 1);
+            hline.PositionDragged += new EventHandler<double>(OnDrag);
             formsPlot1.Render();
             UpdateMessage();
         }
@@ -45,9 +46,24 @@ namespace ScottPlotDemos
         private void BtnAddVline_Click(object sender, EventArgs e)
         {
             double position = rand.NextDouble() * 50;
-            formsPlot1.plt.PlotVLine(position, draggable: true, dragLimitLower: 0, dragLimitUpper: 49);
+            var vline = formsPlot1.plt.PlotVLine(position, draggable: true, dragLimitLower: 0, dragLimitUpper: 49);
+            vline.PositionDragged += new EventHandler<double>(OnDrag);
             formsPlot1.Render();
             UpdateMessage();
+        }
+
+        private void OnDrag(object sender, double newPosition)
+        {
+            if (sender is ScottPlot.PlottableAxLine axLine)
+            {
+                string orientation = (axLine.vertical) ? "vertical" : "horizontal";
+                Text = $"Moved {orientation} axis line to new position: {newPosition}";
+            }
+            else if (sender is ScottPlot.PlottableAxSpan axSpan)
+            {
+                string orientation = (axSpan.vertical) ? "horizontal" : "vertical";
+                Text = $"Moved {orientation} axis span edge to new position: {newPosition}";
+            }
         }
 
         private void BtnClearLines_Click(object sender, EventArgs e)
@@ -102,7 +118,9 @@ namespace ScottPlotDemos
         {
             (double y1, double y2) = ScottPlot.DataGen.RandomSpan(rand: null, low: -1, high: 1, minimumSpacing: .25);
 
-            formsPlot1.plt.PlotHSpan(y1, y2, draggable: true, dragLimitLower: -1, dragLimitUpper: 1);
+            var hspan = formsPlot1.plt.PlotHSpan(y1, y2, draggable: true, dragLimitLower: -1, dragLimitUpper: 1);
+            hspan.Position1Dragged += OnDrag;
+            hspan.Position2Dragged += OnDrag;
             formsPlot1.Render();
             UpdateMessage();
         }
@@ -111,7 +129,9 @@ namespace ScottPlotDemos
         {
             (double x1, double x2) = ScottPlot.DataGen.RandomSpan(rand: null, low: 0, high: 50, minimumSpacing: 10);
 
-            formsPlot1.plt.PlotVSpan(x1, x2, draggable: true, dragLimitLower: 0, dragLimitUpper: 50);
+            var vspan = formsPlot1.plt.PlotVSpan(x1, x2, draggable: true, dragLimitLower: 0, dragLimitUpper: 50);
+            vspan.Position1Dragged += OnDrag;
+            vspan.Position2Dragged += OnDrag;
             formsPlot1.Render();
             UpdateMessage();
         }

--- a/demos/WinForms/Demos/FormDraggableAxisLines.cs
+++ b/demos/WinForms/Demos/FormDraggableAxisLines.cs
@@ -38,7 +38,7 @@ namespace ScottPlotDemos
         {
             double position = rand.NextDouble() * 2 - 1;
             var hline = formsPlot1.plt.PlotHLine(position, draggable: true, dragLimitLower: -1, dragLimitUpper: 1);
-            hline.PositionDragged += new EventHandler<double>(OnDrag);
+            hline.Dragged += new EventHandler(OnDrag);
             formsPlot1.Render();
             UpdateMessage();
         }
@@ -47,22 +47,42 @@ namespace ScottPlotDemos
         {
             double position = rand.NextDouble() * 50;
             var vline = formsPlot1.plt.PlotVLine(position, draggable: true, dragLimitLower: 0, dragLimitUpper: 49);
-            vline.PositionDragged += new EventHandler<double>(OnDrag);
+            vline.Dragged += new EventHandler(OnDrag);
             formsPlot1.Render();
             UpdateMessage();
         }
 
-        private void OnDrag(object sender, double newPosition)
+        private void BtnAddHspan_Click(object sender, EventArgs e)
+        {
+            (double y1, double y2) = ScottPlot.DataGen.RandomSpan(rand: null, low: -1, high: 1, minimumSpacing: .25);
+
+            var hspan = formsPlot1.plt.PlotHSpan(y1, y2, draggable: true, dragLimitLower: -1, dragLimitUpper: 1);
+            hspan.DraggedPosition1 += OnDrag; // if you want different behavior for different positions, create different functions
+            hspan.DraggedPosition2 += OnDrag;
+            formsPlot1.Render();
+            UpdateMessage();
+        }
+
+        private void BtnAddVSpan_Click(object sender, EventArgs e)
+        {
+            (double x1, double x2) = ScottPlot.DataGen.RandomSpan(rand: null, low: 0, high: 50, minimumSpacing: 10);
+
+            var vspan = formsPlot1.plt.PlotVSpan(x1, x2, draggable: true, dragLimitLower: 0, dragLimitUpper: 50);
+            vspan.DraggedPosition1 += OnDrag; // if you want different behavior for different positions, create different functions
+            vspan.DraggedPosition2 += OnDrag;
+            formsPlot1.Render();
+            UpdateMessage();
+        }
+
+        private void OnDrag(object sender, EventArgs e)
         {
             if (sender is ScottPlot.PlottableAxLine axLine)
             {
-                string orientation = (axLine.vertical) ? "vertical" : "horizontal";
-                Text = $"Moved {orientation} axis line to new position: {newPosition}";
+                Text = $"Adjusted axis line: {axLine.position}";
             }
             else if (sender is ScottPlot.PlottableAxSpan axSpan)
             {
-                string orientation = (axSpan.vertical) ? "horizontal" : "vertical";
-                Text = $"Moved {orientation} axis span edge to new position: {newPosition}";
+                Text = $"Adjusted axis span: {axSpan.position1} to {axSpan.position2}";
             }
         }
 
@@ -112,28 +132,6 @@ namespace ScottPlotDemos
             Console.WriteLine("Dropped a plottable object");
             UpdateMessage();
             richTextBox1.Enabled = true;
-        }
-
-        private void BtnAddHspan_Click(object sender, EventArgs e)
-        {
-            (double y1, double y2) = ScottPlot.DataGen.RandomSpan(rand: null, low: -1, high: 1, minimumSpacing: .25);
-
-            var hspan = formsPlot1.plt.PlotHSpan(y1, y2, draggable: true, dragLimitLower: -1, dragLimitUpper: 1);
-            hspan.Position1Dragged += OnDrag;
-            hspan.Position2Dragged += OnDrag;
-            formsPlot1.Render();
-            UpdateMessage();
-        }
-
-        private void BtnAddVSpan_Click(object sender, EventArgs e)
-        {
-            (double x1, double x2) = ScottPlot.DataGen.RandomSpan(rand: null, low: 0, high: 50, minimumSpacing: 10);
-
-            var vspan = formsPlot1.plt.PlotVSpan(x1, x2, draggable: true, dragLimitLower: 0, dragLimitUpper: 50);
-            vspan.Position1Dragged += OnDrag;
-            vspan.Position2Dragged += OnDrag;
-            formsPlot1.Render();
-            UpdateMessage();
         }
 
         private void BtnClearSpans_Click(object sender, EventArgs e)

--- a/demos/WinForms/FormMain.cs
+++ b/demos/WinForms/FormMain.cs
@@ -24,8 +24,8 @@ namespace ScottPlotDemos
 
             if (Debugger.IsAttached)
             {
-                //btnPlotTypes_Click(null, null);
-                btnDraggableAxisLines_Click(null, null);
+                btnPlotTypes_Click(null, null);
+                //btnDraggableAxisLines_Click(null, null);
                 //btnSignal_Click(null, null);
                 //btnTimeAxis_Click(null, null);
                 //btnFinancial_Click(null, null);

--- a/demos/WinForms/FormMain.cs
+++ b/demos/WinForms/FormMain.cs
@@ -24,8 +24,8 @@ namespace ScottPlotDemos
 
             if (Debugger.IsAttached)
             {
-                btnPlotTypes_Click(null, null);
-                //btnDraggableAxisLines_Click(null, null);
+                //btnPlotTypes_Click(null, null);
+                btnDraggableAxisLines_Click(null, null);
                 //btnSignal_Click(null, null);
                 //btnTimeAxis_Click(null, null);
                 //btnFinancial_Click(null, null);

--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -272,7 +272,7 @@ namespace ScottPlot
                 OnAxisChanged();
             }
 
-            if (plottableBeingDragged != null)
+            if (isMovingDraggable)
             {
                 OnMouseDropPlottable(EventArgs.Empty);
             }

--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -54,7 +54,7 @@ namespace ScottPlot
             {
                 currentlyRendering = true;
                 pbPlot.Image = plt?.GetBitmap(true, lowQuality);
-                if (isPanningOrZooming)
+                if (isPanningOrZooming || isMovingDraggable)
                     Application.DoEvents();
                 currentlyRendering = false;
             }

--- a/src/ScottPlot/plottables/PlottableAxLine.cs
+++ b/src/ScottPlot/plottables/PlottableAxLine.cs
@@ -17,7 +17,7 @@ namespace ScottPlot
         public bool horizontal { get { return !vertical; } }
         private string orientation { get { return (vertical) ? "vertical" : "horizontal"; } }
 
-        public event EventHandler<double> PositionDragged = delegate { };
+        public event EventHandler Dragged = delegate { };
 
         public PlottableAxLine(double position, bool vertical, Color color, double lineWidth, string label,
             bool draggable, double dragLimitLower, double dragLimitUpper, LineStyle lineStyle)
@@ -119,14 +119,14 @@ namespace ScottPlot
                     if (coordinateX < dragLimitX1) coordinateX = dragLimitX1;
                     if (coordinateX > dragLimitX2) coordinateX = dragLimitX2;
                     position = coordinateX;
-                    PositionDragged(this, position);
+                    Dragged(this, EventArgs.Empty);
                 }
                 else
                 {
                     if (coordinateY < dragLimitY1) coordinateY = dragLimitY1;
                     if (coordinateY > dragLimitY2) coordinateY = dragLimitY2;
                     position = coordinateY;
-                    PositionDragged(this, position);
+                    Dragged(this, EventArgs.Empty);
                 }
             }
         }

--- a/src/ScottPlot/plottables/PlottableAxLine.cs
+++ b/src/ScottPlot/plottables/PlottableAxLine.cs
@@ -17,6 +17,8 @@ namespace ScottPlot
         public bool horizontal { get { return !vertical; } }
         private string orientation { get { return (vertical) ? "vertical" : "horizontal"; } }
 
+        public event EventHandler<double> PositionDragged = delegate { };
+
         public PlottableAxLine(double position, bool vertical, Color color, double lineWidth, string label,
             bool draggable, double dragLimitLower, double dragLimitUpper, LineStyle lineStyle)
         {
@@ -117,12 +119,14 @@ namespace ScottPlot
                     if (coordinateX < dragLimitX1) coordinateX = dragLimitX1;
                     if (coordinateX > dragLimitX2) coordinateX = dragLimitX2;
                     position = coordinateX;
+                    PositionDragged(this, position);
                 }
                 else
                 {
                     if (coordinateY < dragLimitY1) coordinateY = dragLimitY1;
                     if (coordinateY > dragLimitY2) coordinateY = dragLimitY2;
                     position = coordinateY;
+                    PositionDragged(this, position);
                 }
             }
         }

--- a/src/ScottPlot/plottables/PlottableAxSpan.cs
+++ b/src/ScottPlot/plottables/PlottableAxSpan.cs
@@ -18,8 +18,8 @@ namespace ScottPlot
         public bool horizontal { get { return !vertical; } }
         private string orientation { get { return (vertical) ? "vertical" : "horizontal"; } }
 
-        public event EventHandler<double> Position1Dragged = delegate { };
-        public event EventHandler<double> Position2Dragged = delegate { };
+        public event EventHandler DraggedPosition1 = delegate { };
+        public event EventHandler DraggedPosition2 = delegate { };
 
         public PlottableAxSpan(double position1, double position2, bool vertical, Color color, double alpha, string label,
             bool draggable, double dragLimitLower, double dragLimitUpper)
@@ -140,12 +140,12 @@ namespace ScottPlot
                     if (positionUnderMouse == 1)
                     {
                         position1 = coordinateX;
-                        Position1Dragged(this, position1);
+                        DraggedPosition1(this, EventArgs.Empty);
                     }
                     else if (positionUnderMouse == 2)
-                    { 
+                    {
                         position2 = coordinateX;
-                        Position2Dragged(this, position2);
+                        DraggedPosition2(this, EventArgs.Empty);
                     }
                 }
                 else
@@ -156,12 +156,12 @@ namespace ScottPlot
                     if (positionUnderMouse == 1)
                     {
                         position1 = coordinateY;
-                        Position1Dragged(this, position1);
+                        DraggedPosition1(this, EventArgs.Empty);
                     }
                     else if (positionUnderMouse == 2)
                     {
                         position2 = coordinateY;
-                        Position2Dragged(this, position2);
+                        DraggedPosition2(this, EventArgs.Empty);
                     }
                 }
             }

--- a/src/ScottPlot/plottables/PlottableAxSpan.cs
+++ b/src/ScottPlot/plottables/PlottableAxSpan.cs
@@ -18,6 +18,9 @@ namespace ScottPlot
         public bool horizontal { get { return !vertical; } }
         private string orientation { get { return (vertical) ? "vertical" : "horizontal"; } }
 
+        public event EventHandler<double> Position1Dragged = delegate { };
+        public event EventHandler<double> Position2Dragged = delegate { };
+
         public PlottableAxSpan(double position1, double position2, bool vertical, Color color, double alpha, string label,
             bool draggable, double dragLimitLower, double dragLimitUpper)
         {
@@ -135,9 +138,15 @@ namespace ScottPlot
                     if (coordinateX > dragLimitX2) coordinateX = dragLimitX2;
 
                     if (positionUnderMouse == 1)
+                    {
                         position1 = coordinateX;
+                        Position1Dragged(this, position1);
+                    }
                     else if (positionUnderMouse == 2)
+                    { 
                         position2 = coordinateX;
+                        Position2Dragged(this, position2);
+                    }
                 }
                 else
                 {
@@ -145,9 +154,15 @@ namespace ScottPlot
                     if (coordinateY > dragLimitY2) coordinateY = dragLimitY2;
 
                     if (positionUnderMouse == 1)
+                    {
                         position1 = coordinateY;
+                        Position1Dragged(this, position1);
+                    }
                     else if (positionUnderMouse == 2)
+                    {
                         position2 = coordinateY;
+                        Position2Dragged(this, position2);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add `PositionDragged` event to `PlottableAxLine`.
Add `Position1Dragged` and `Position2Dragged` events to `PlottableAxSpan`.
This events simplify binding UI elements to `Draggable` objects. 
Usage example:
```c#
var plot = formsPlot.plt.PlotVSpan(...)
plot.Position1Dragged += (sender, arg) => form1.TextBox1.Text = arg.ToString();
plot.Position2Dragged += (sender, arg) => form1.TextBox2.Text = arg.ToString();
```

Additionaly this PR force `fix lag while dragging` to `master` branch from `dev/4.1 branch` c7636a52e7fb65a663d5227d9c2560966b06edc7