### PR TITLE
BoxAndWhisker improvements

### DIFF
--- a/src/ScottPlot/Statistics/BoxAndWhisker.cs
+++ b/src/ScottPlot/Statistics/BoxAndWhisker.cs
@@ -44,6 +44,7 @@ namespace ScottPlot.Statistics
         public Midline midline = new Midline();
         public double xPosition;
         public string label;
+        public double[] points;
 
         public BoxAndWhisker(double xPosition)
         {

--- a/src/ScottPlot/Statistics/BoxAndWhisker.cs
+++ b/src/ScottPlot/Statistics/BoxAndWhisker.cs
@@ -49,6 +49,7 @@ namespace ScottPlot.Statistics
         public BoxAndWhisker(double xPosition)
         {
             this.xPosition = xPosition;
+            points = new double[] { };
             ResetStyle();
         }
 

--- a/src/ScottPlot/Statistics/BoxAndWhiskerFromData.cs
+++ b/src/ScottPlot/Statistics/BoxAndWhiskerFromData.cs
@@ -17,8 +17,6 @@ namespace ScottPlot.Statistics
             baw.box.max = stats.mean + stats.stDev;
             baw.box.min = stats.mean - stats.stDev;
 
-            baw.points = new double[]{ };
-
             return baw;
         }
 

--- a/src/ScottPlot/Statistics/BoxAndWhiskerFromData.cs
+++ b/src/ScottPlot/Statistics/BoxAndWhiskerFromData.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ScottPlot.Statistics
+{
+    public static class BoxAndWhiskerFromData
+    {
+        public static BoxAndWhisker GetBoxAndWhisker_LimitsAndDeviation(double[] data, double xPosition)
+        {
+            var baw = new BoxAndWhisker(xPosition);
+
+            var stats = new PopulationStats(data);
+            baw.midline.position = stats.median;
+            baw.whisker.max = stats.max;
+            baw.whisker.min = stats.min;
+            baw.box.max = stats.mean + stats.stDev;
+            baw.box.min = stats.mean - stats.stDev;
+
+            baw.points = new double[]{ };
+
+            return baw;
+        }
+
+        public static BoxAndWhisker GetBoxAndWhisker_OutliersAndQuartiles(double[] data, double xPosition)
+        {
+            var baw = new BoxAndWhisker(xPosition);
+
+            var stats = new PopulationStats(data);
+            baw.midline.position = stats.median;
+            baw.whisker.max = stats.highOutliers.Length == 0 ? stats.maxNonOutlier : stats.Q3 + 1.5 * stats.IQR;
+            baw.whisker.min = stats.lowOutliers.Length == 0 ? stats.minNonOutlier : stats.Q1 - 1.5 * stats.IQR;
+            baw.box.max = stats.Q3;
+            baw.box.min = stats.Q1;
+
+            List<double> pointsList = new List<double>();
+            pointsList.AddRange(stats.highOutliers);
+            pointsList.AddRange(stats.lowOutliers);
+            baw.points = pointsList.ToArray();
+
+            return baw;
+        }
+    }
+}

--- a/src/ScottPlot/Statistics/PopulationStats.cs
+++ b/src/ScottPlot/Statistics/PopulationStats.cs
@@ -16,6 +16,13 @@ namespace ScottPlot.Statistics
         public readonly double mean;
         public readonly double stDev;
         public readonly double stdErr;
+        public readonly double Q1;
+        public readonly double Q3;
+        public readonly double IQR;
+        public readonly double[] lowOutliers;
+        public readonly double[] highOutliers;
+        public readonly double maxNonOutlier;
+        public readonly double minNonOutlier;
 
         public PopulationStats(double[] values, bool fullAnalysis = true)
         {
@@ -26,6 +33,8 @@ namespace ScottPlot.Statistics
 
             if (fullAnalysis)
             {
+                int QSize = (int)Math.Floor(count / 4.0);
+
                 sortedValues = new double[count];
                 Array.Copy(values, 0, sortedValues, 0, count);
                 Array.Sort(sortedValues);
@@ -33,6 +42,19 @@ namespace ScottPlot.Statistics
                 min = sortedValues.First();
                 max = sortedValues.Last();
                 median = sortedValues[count / 2];
+
+                Q1 = sortedValues[QSize];
+                Q3 = sortedValues[sortedValues.Length - QSize - 1];
+                IQR = Q3 - Q1;
+
+                double lowerBoundary = Q1 - 1.5 * IQR;
+                double upperBoundary = Q3 + 1.5 * IQR;
+
+                //These could be made faster knowing that we have already sorted the list above 
+                lowOutliers = sortedValues.Where(y => y < lowerBoundary).ToArray();
+                highOutliers = sortedValues.Where(y => y > upperBoundary).ToArray();
+                minNonOutlier = sortedValues.Where(y => y > lowerBoundary).FirstOrDefault();
+                maxNonOutlier = sortedValues.Where(y => y < upperBoundary).LastOrDefault();
             }
             else
             {

--- a/src/ScottPlot/Statistics/PopulationStats.cs
+++ b/src/ScottPlot/Statistics/PopulationStats.cs
@@ -50,8 +50,6 @@ namespace ScottPlot.Statistics
                 double lowerBoundary = Q1 - 1.5 * IQR;
                 double upperBoundary = Q3 + 1.5 * IQR;
 
-                List<double> lowOutliersList = new List<double>();
-                List<double> highOutliersList = new List<double>();
                 int minNonOutlierIndex = 0;
                 int maxNonOutlierIndex = 0;
 
@@ -59,7 +57,7 @@ namespace ScottPlot.Statistics
                 {
                     if (sortedValues[i] < lowerBoundary)
                     {
-                        lowOutliersList.Add(sortedValues[i]);
+
                     }
                     else
                     {
@@ -72,7 +70,7 @@ namespace ScottPlot.Statistics
                 {
                     if (sortedValues[i] > upperBoundary)
                     {
-                        highOutliersList.Add(sortedValues[i]);
+
                     }
                     else
                     {
@@ -81,24 +79,10 @@ namespace ScottPlot.Statistics
                     }
                 }
 
-                if (lowOutliersList.Count() > 0)
-                {
-                    lowOutliers = lowOutliersList.ToArray();
-                }
-                else
-                {
-                    lowOutliers = new double[] { };
-                }
-
-                if (highOutliersList.Count() > 0)
-                {
-                    highOutliers = highOutliersList.ToArray();
-                }
-                else
-                {
-                    highOutliers = new double[] { };
-                }
-
+                lowOutliers = new double[minNonOutlierIndex];
+                highOutliers = new double[sortedValues.Length - maxNonOutlierIndex - 1];
+                Array.Copy(sortedValues, 0, lowOutliers, 0, lowOutliers.Length);
+                Array.Copy(sortedValues, maxNonOutlierIndex + 1, highOutliers, 0, highOutliers.Length);
                 minNonOutlier = sortedValues[minNonOutlierIndex];
                 maxNonOutlier = sortedValues[maxNonOutlierIndex];
             }

--- a/src/ScottPlot/Statistics/PopulationStats.cs
+++ b/src/ScottPlot/Statistics/PopulationStats.cs
@@ -50,11 +50,57 @@ namespace ScottPlot.Statistics
                 double lowerBoundary = Q1 - 1.5 * IQR;
                 double upperBoundary = Q3 + 1.5 * IQR;
 
-                //These could be made faster knowing that we have already sorted the list above 
-                lowOutliers = sortedValues.Where(y => y < lowerBoundary).ToArray();
-                highOutliers = sortedValues.Where(y => y > upperBoundary).ToArray();
-                minNonOutlier = sortedValues.Where(y => y > lowerBoundary).FirstOrDefault();
-                maxNonOutlier = sortedValues.Where(y => y < upperBoundary).LastOrDefault();
+                List<double> lowOutliersList = new List<double>();
+                List<double> highOutliersList = new List<double>();
+                int minNonOutlierIndex = 0;
+                int maxNonOutlierIndex = 0;
+
+                for (int i = 0; i < sortedValues.Length; i++)
+                {
+                    if (sortedValues[i] < lowerBoundary)
+                    {
+                        lowOutliersList.Add(sortedValues[i]);
+                    }
+                    else
+                    {
+                        minNonOutlierIndex = i;
+                        break;
+                    }
+                }
+
+                for (int i = sortedValues.Length - 1; i >= 0; i--)
+                {
+                    if (sortedValues[i] > upperBoundary)
+                    {
+                        highOutliersList.Add(sortedValues[i]);
+                    }
+                    else
+                    {
+                        maxNonOutlierIndex = i;
+                        break;
+                    }
+                }
+
+                if (lowOutliersList.Count() > 0)
+                {
+                    lowOutliers = lowOutliersList.ToArray();
+                }
+                else
+                {
+                    lowOutliers = new double[] { };
+                }
+
+                if (highOutliersList.Count() > 0)
+                {
+                    highOutliers = highOutliersList.ToArray();
+                }
+                else
+                {
+                    highOutliers = new double[] { };
+                }
+
+                minNonOutlier = sortedValues[minNonOutlierIndex];
+                maxNonOutlier = sortedValues[maxNonOutlierIndex];
             }
             else
             {

--- a/src/ScottPlot/plottables/PlottableBoxAndWhisker.cs
+++ b/src/ScottPlot/plottables/PlottableBoxAndWhisker.cs
@@ -27,7 +27,11 @@ namespace ScottPlot
                 limits.ExpandY(box.box.min, box.box.max);
                 limits.ExpandY(box.whisker.min, box.whisker.max);
                 limits.ExpandY(box.midline.position, box.midline.position);
-                limits.ExpandY(box.points.Min(), box.points.Max());
+
+                if (box.points.Count() > 0) //Cannot call Min() or Max() on empty list
+                {
+                    limits.ExpandY(box.points.Min(), box.points.Max());
+                }
             }
             return limits;
         }

--- a/src/ScottPlot/plottables/PlottableBoxAndWhisker.cs
+++ b/src/ScottPlot/plottables/PlottableBoxAndWhisker.cs
@@ -87,6 +87,11 @@ namespace ScottPlot
                     var mindlinePen = new Pen(baw.midline.lineColor, baw.midline.lineWidth);
                     settings.gfxData.DrawLine(mindlinePen, boxLeft, midlineY, boxRight, midlineY);
                 }
+
+                foreach (double curr in baw.points) {
+                    PointF point = new PointF(center, (float) settings.GetPixelY(curr));
+                    MarkerTools.DrawMarker(settings.gfxData, point, MarkerShape.asterisk, 6, color);
+                }
             }
         }
 

--- a/src/ScottPlot/plottables/PlottableBoxAndWhisker.cs
+++ b/src/ScottPlot/plottables/PlottableBoxAndWhisker.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 
 namespace ScottPlot
@@ -26,6 +27,7 @@ namespace ScottPlot
                 limits.ExpandY(box.box.min, box.box.max);
                 limits.ExpandY(box.whisker.min, box.whisker.max);
                 limits.ExpandY(box.midline.position, box.midline.position);
+                limits.ExpandY(box.points.Min(), box.points.Max());
             }
             return limits;
         }


### PR DESCRIPTION
… individual points

As before, here is the code that I used to test:

```
using ScottPlot;
using System;
using System.Diagnostics;

namespace ScottPlotTesting
{
	class Program
	{
		static void Main(string[] args)
		{
			Random rand = new Random();
			var plt = new ScottPlot.Plot(600, 400);
			string filename = "test.png";
			double[] xs = new double[3];
			double[][] ys = new double[3][];
			for (int i = 0; i < ys.Length; i++)
			{
				xs[i] = i;
				ys[i] = new double[10];
				for (int j = 0; j < 10; j++)
				{
					if (j == 0)
					{
						ys[i][j] = 2;//Just to guarantee that there is an outlier
						continue;
					}
					ys[i][j] = rand.NextDouble();
				}
			}

			ScottPlot.Statistics.BoxAndWhisker[] boxAndWhisker = new ScottPlot.Statistics.BoxAndWhisker[ys.Length];
			for (int i = 0; i < ys.Length; i++) {
				boxAndWhisker[i] = ScottPlot.Statistics.BoxAndWhiskerFromData.GetBoxAndWhisker_OutliersAndQuartiles(ys[i], i);
			}
			plt.PlotBoxAndWhisker(boxAndWhisker);

			plt.SaveFig(filename);

			using (Process proc = new Process())
			{ // This is to open the file automatically, if you're on linux, you need xdg-open
				proc.StartInfo.FileName = filename;
				proc.StartInfo.UseShellExecute = true;
				proc.Start();
			}
		}
	}
}

```

You can use `Statistics.BoxAndWhiskerFromData.GetBoxAndWhisker_OutliersAndQuartiles` or `Statistics.BoxAndWhiskerFromData.GetBoxAndWhisker_LimitsAndDeviation`, I tested both, they both work fine.