### PR TITLE
optimize Signal & create parallel processing tests

### DIFF
--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -54,8 +54,8 @@ namespace ScottPlot
         public Rectangle? mouseMiddleRect = null;
 
         // scales calculations must occur at this level because the axes are unaware of pixel dimensions
-        public double xAxisScale { get { return bmpData.Width / axes.x.span; } } // pixels per unit
-        public double yAxisScale { get { return bmpData.Height / axes.y.span; } } // pixels per unit
+        public double xAxisScale { get { return dataSize.Width / axes.x.span; } } // pixels per unit
+        public double yAxisScale { get { return dataSize.Height / axes.y.span; } } // pixels per unit
         public double xAxisUnitsPerPixel { get { return 1.0 / xAxisScale; } }
         public double yAxisUnitsPerPixel { get { return 1.0 / yAxisScale; } }
 

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -54,8 +54,8 @@ namespace ScottPlot
         public Rectangle? mouseMiddleRect = null;
 
         // scales calculations must occur at this level because the axes are unaware of pixel dimensions
-        public double xAxisScale { get { return dataSize.Width / axes.x.span; } } // pixels per unit
-        public double yAxisScale { get { return dataSize.Height / axes.y.span; } } // pixels per unit
+        public double xAxisScale { get { return bmpData.Width / axes.x.span; } } // pixels per unit
+        public double yAxisScale { get { return bmpData.Height / axes.y.span; } } // pixels per unit
         public double xAxisUnitsPerPixel { get { return 1.0 / xAxisScale; } }
         public double yAxisUnitsPerPixel { get { return 1.0 / yAxisScale; } }
 

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Drawing;
-using System.Linq.Expressions;
 
 namespace ScottPlot
 {
@@ -151,8 +150,8 @@ namespace ScottPlot
                     if (ys[i] > highestValue)
                         highestValue = ys[i];
                 }
-                float yPxHigh = settings.GetPixel(0, lowestValue + yOffset).Y;
-                float yPxLow = settings.GetPixel(0, highestValue + yOffset).Y;
+                float yPxHigh = (float)settings.GetPixelY(lowestValue + yOffset);
+                float yPxLow = (float)settings.GetPixelY(highestValue + yOffset);
 
                 linePoints[(xPx - xPxStart) * 2] = new PointF(xPx, yPxLow);
                 linePoints[(xPx - xPxStart) * 2 + 1] = new PointF(xPx, yPxHigh);
@@ -203,8 +202,8 @@ namespace ScottPlot
                     .Where((y, i) => indexes.Contains(i));
 
                 var Points = levelsValues
-                    .Select(x => settings.GetPixel(0, x + yOffset).Y)
-                    .Select(y => new PointF(xPx, y))
+                    .Select(x => settings.GetPixelY(x + yOffset))
+                    .Select(y => new PointF(xPx, (float)y))
                     .ToArray();
 
                 linePointsLevels.Add(Points);
@@ -261,7 +260,7 @@ namespace ScottPlot
 
             List<PointF[]> linePointsLevels = levelValues
                 .Select(x => x.levelsValues
-                                .Select(y => new PointF(x.xPx, settings.GetPixel(0, y + yOffset).Y))
+                                .Select(y => new PointF(x.xPx, (float)settings.GetPixelY(y + yOffset)))
                                 .ToArray())
                 .ToList();
 
@@ -320,8 +319,8 @@ namespace ScottPlot
                     if (ys[i] > highestValue)
                         highestValue = ys[i];
                 }
-                float yPxHigh = settings.GetPixel(0, lowestValue + yOffset).Y;
-                float yPxLow = settings.GetPixel(0, highestValue + yOffset).Y;
+                float yPxHigh = (float)settings.GetPixelY(lowestValue + yOffset);
+                float yPxLow = (float)settings.GetPixelY(highestValue + yOffset);
 
                 // adjust order of points to enhance anti-aliasing
                 if ((linePoints.Count < 2) || (yPxLow < linePoints[linePoints.Count - 1].Y))

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -282,7 +282,6 @@ namespace ScottPlot
         private void RenderHighDensity(Settings settings, double offsetPoints, double columnPointCount)
         {
             // this function is for when the graph is zoomed out so each pixel column represents the vertical span of multiple data points
-
             int xPxStart = (int)Math.Ceiling((-1 - offsetPoints) / columnPointCount - 1);
             int xPxEnd = (int)Math.Ceiling((ys.Length - offsetPoints) / columnPointCount);
             xPxStart = Math.Max(0, xPxStart);

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -16,7 +16,7 @@ namespace ScottPlot
     // - if source array is changed UpdateTrees() must be called
     // - source array can be change by call updateData(), updating by ranges much faster.
     public class PlottableSignalConst<T> : Plottable, IExportable where T : struct, IComparable
-    {    
+    {
         // Any changes must be sync with PlottableSignal
         public T[] ys;
         public double sampleRate;
@@ -86,14 +86,14 @@ namespace ScottPlot
                 LineJoin = System.Drawing.Drawing2D.LineJoin.Round
             };
             try // runtime check
-            {               
+            {
                 Convert.ToDouble(new T());
             }
-            catch 
+            catch
             {
                 throw new ArgumentOutOfRangeException("Unsupported data type, provide convertable to double data types");
             }
-            InitExp();         
+            InitExp();
             if (useParallel)
                 UpdateTreesInBackground();
             else
@@ -352,7 +352,7 @@ namespace ScottPlot
         {
             // this function is for when the graph is zoomed so far out its entire display is a single vertical pixel column
             double yMin, yMax;
-            MinMaxRangeQuery(0, ys.Length - 1, out yMin, out yMax);            
+            MinMaxRangeQuery(0, ys.Length - 1, out yMin, out yMax);
             PointF point1 = settings.GetPixel(xOffset, yMin + yOffset);
             PointF point2 = settings.GetPixel(xOffset, yMax + yOffset);
             settings.gfxData.DrawLine(pen, point1, point2);
@@ -401,8 +401,9 @@ namespace ScottPlot
                 // get the min and max value for this column                
                 double lowestValue, highestValue;
                 MinMaxRangeQuery(index1, index2, out lowestValue, out highestValue);
-                float yPxHigh = settings.GetPixel(0, lowestValue + yOffset).Y;
-                float yPxLow = settings.GetPixel(0, highestValue + yOffset).Y;
+                float yPxHigh = (float)settings.GetPixelY(lowestValue + yOffset);
+                float yPxLow = (float)settings.GetPixelY(highestValue + yOffset);
+
 
                 linePoints[(xPx - xPxStart) * 2] = new PointF(xPx, yPxLow);
                 linePoints[(xPx - xPxStart) * 2 + 1] = new PointF(xPx, yPxHigh);
@@ -445,10 +446,10 @@ namespace ScottPlot
                     index2 = ys.Length - 1;
 
                 // get the min and max value for this column                
-                double lowestValue, highestValue;                
+                double lowestValue, highestValue;
                 MinMaxRangeQuery(index1, index2, out lowestValue, out highestValue);
-                float yPxHigh = settings.GetPixel(0, lowestValue + yOffset).Y;
-                float yPxLow = settings.GetPixel(0, highestValue + yOffset).Y;
+                float yPxHigh = (float)settings.GetPixelY(lowestValue + yOffset);
+                float yPxLow = (float)settings.GetPixelY(highestValue + yOffset);
 
                 // adjust order of points to enhance anti-aliasing
                 if ((linePoints.Count < 2) || (yPxLow < linePoints[linePoints.Count - 1].Y))

--- a/tests/MultiThreadingTests.cs
+++ b/tests/MultiThreadingTests.cs
@@ -1,0 +1,132 @@
+﻿using NUnit.Framework;
+using System;
+using System.Drawing;
+using System.Linq;
+
+namespace ScottPlotTests
+{
+    [TestFixture]
+    public class MultiThreadingTests
+    {
+        [Test]
+        public void Signal_RenderHighDensityParallel_NotThrows()
+        {
+            double[] TestArray = Enumerable.Range(0, 5000).Select(x => Math.Sin(x / 10)).ToArray();
+
+            var plt = new ScottPlot.Plot(800, 400);
+            plt.GetSettings().misc.useParallel = true;
+            plt.PlotSignal(TestArray);
+
+            Assert.DoesNotThrow(() => plt.GetBitmap());
+        }
+
+        [Test]
+        public void Signal_RenderHighDensityDistributionParallel_NotThrows()
+        {
+            double[] TestArray = Enumerable.Range(0, 5000).Select(x => Math.Sin(x / 10)).ToArray();
+            Color[] Levels = new Color[] { Color.Red, Color.Green, Color.Red };
+
+            var plt = new ScottPlot.Plot(800, 400);
+            plt.GetSettings().misc.useParallel = true;
+            plt.PlotSignal(TestArray, colorByDensity: Levels);
+
+            Assert.DoesNotThrow(() => plt.GetBitmap());
+        }
+
+        [Test]
+        public void SignalConst_RenderHighDensityParallel_NotThrows()
+        {
+            double[] TestArray = Enumerable.Range(0, 5000).Select(x => Math.Sin(x / 10)).ToArray();
+
+            var plt = new ScottPlot.Plot(800, 400);
+            plt.GetSettings().misc.useParallel = true;
+            plt.PlotSignalConst(TestArray);
+
+            Assert.DoesNotThrow(() => plt.GetBitmap());
+        }
+
+        [Test]
+        public void GetPixel_MultipleParallelCalls_NotThrows()
+        {
+            var plt = new ScottPlot.Plot(800, 400);
+            var settings = plt.GetSettings();
+
+            var pixels = Enumerable.Range(0, 5000).AsParallel().Select(x => settings.GetPixel(x, x * 3));
+
+            Assert.DoesNotThrow(() =>
+            {
+                var array = pixels.ToArray();
+            });
+        }
+
+        [Test]
+        public void GetPixelX_MultipleParallelCalls_NotThrows()
+        {
+            var plt = new ScottPlot.Plot(800, 400);
+            var settings = plt.GetSettings();
+
+            var pixels = Enumerable.Range(0, 5000).AsParallel().Select(x => settings.GetPixelX(x));
+
+            Assert.DoesNotThrow(() =>
+            {
+                var array = pixels.ToArray();
+            });
+        }
+
+        [Test]
+        public void GetPixelY_MultipleParallelCalls_NotThrows()
+        {
+            var plt = new ScottPlot.Plot(800, 400);
+            var settings = plt.GetSettings();
+
+            var pixels = Enumerable.Range(0, 5000).AsParallel().Select(x => settings.GetPixelY(x * 3));
+
+            Assert.DoesNotThrow(() =>
+            {
+                var array = pixels.ToArray();
+            });
+        }
+
+        [Test]
+        public void GetLocation_MultipleParallelCalls_NotThrows()
+        {
+            var plt = new ScottPlot.Plot(800, 400);
+            var settings = plt.GetSettings();
+
+            var pixels = Enumerable.Range(0, 5000).AsParallel().Select(x => settings.GetLocation(x, x * 3));
+
+            Assert.DoesNotThrow(() =>
+            {
+                var array = pixels.ToArray();
+            });
+        }
+
+        [Test]
+        public void GetLocationX_MultipleParallelCalls_NotThrows()
+        {
+            var plt = new ScottPlot.Plot(800, 400);
+            var settings = plt.GetSettings();
+
+            var pixels = Enumerable.Range(0, 5000).AsParallel().Select(x => settings.GetLocationX(x));
+
+            Assert.DoesNotThrow(() =>
+            {
+                var array = pixels.ToArray();
+            });
+        }
+
+        [Test]
+        public void GetLocationY_MultipleParallelCalls_NotThrows()
+        {
+            var plt = new ScottPlot.Plot(800, 400);
+            var settings = plt.GetSettings();
+
+            var pixels = Enumerable.Range(0, 5000).AsParallel().Select(x => settings.GetLocationY(x * 3));
+
+            Assert.DoesNotThrow(() =>
+            {
+                var array = pixels.ToArray();
+            });
+        }
+    }
+}


### PR DESCRIPTION
Add tests for currently implemented parallel renderers.
Additionaly tests for thread safe calls of `Settings.GetPixel` and `Settings.GetLocation` methods.
This PR prevents future Issues like #245.

Replaced `Settings.GetPixel(0, value).Y` with new `Settings.GetPixelY()` in `Signal` and `SignalConst`.