### PR TITLE
Add zero lineWidth and zero markerSize support to Signal and SignalConst

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.0.19
 * Improved thread safety of interactive graphs (#245) _Thanks @StendProg_
 * MultiPlot now has a GetSubplot() method which returns the Plot from a row and column index (#242). See cookbook for details. _Thanks @Resonanz and @StendProg_
+* Improved support for zero lineSize and markerSize in Signal and SignalConst plots (#263, #264) _Thanks @bukkideme and @StendProg_
 
 ## ScottPlot 4.0.18
 * Improved local culture formatting of numerican and DateTime axis tick labels (#236) _Thanks @teejay-87_

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -114,9 +114,14 @@ namespace ScottPlot
 
             if (linePoints.Count > 1)
             {
-                settings.gfxData.DrawLines(pen, linePoints.ToArray());
-                foreach (PointF point in linePoints)
-                    settings.gfxData.FillEllipse(brush, point.X - markerSize / 2, point.Y - markerSize / 2, markerSize, markerSize);
+                if (pen.Width > 0)
+                    settings.gfxData.DrawLines(pen, linePoints.ToArray());
+
+                if (markerSize > 0)
+                {
+                    foreach (PointF point in linePoints)
+                        settings.gfxData.FillEllipse(brush, point.X - markerSize / 2, point.Y - markerSize / 2, markerSize, markerSize);
+                }
             }
         }
 

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -372,9 +372,14 @@ namespace ScottPlot
 
             if (linePoints.Count > 1)
             {
-                settings.gfxData.DrawLines(pen, linePoints.ToArray());
-                foreach (PointF point in linePoints)
-                    settings.gfxData.FillEllipse(brush, point.X - markerSize / 2, point.Y - markerSize / 2, markerSize, markerSize);
+                if (pen.Width > 0)
+                    settings.gfxData.DrawLines(pen, linePoints.ToArray());
+
+                if (markerSize > 0)
+                {
+                    foreach (PointF point in linePoints)
+                        settings.gfxData.FillEllipse(brush, point.X - markerSize / 2, point.Y - markerSize / 2, markerSize, markerSize);
+                }
             }
         }
 


### PR DESCRIPTION
Fix for issue #263.
Add ability to disable drawing lines by setting `lineWidth` to 0 for `Signal` and `SignalConst`.
Add ability to disable drawing points by setting `markerSize` to 0 for `Signal` and `SignalConst`.
This implemented only for `RenderLowDensity` mode.
`RenderHighDensity` mode stay as before.