### PR TITLE
Set pbPlot.BackColor equal to FormsPlot.BackColor

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -34,6 +34,7 @@ _ScottPlot uses [semantic](https://semver.org/) (major.minor.patch) versioning. 
 
 ### Misc
 * Fixed bug that caused `Plot.CoordinateFromPixelY()` to return incorrect value
+* Improved support for WinForms control transparency (#286) _Thanks @StendProg and @envine_
 
 ## ScottPlot 4.0.19
 

--- a/src/ScottPlot.Demo.WinForms/FormDemos.Designer.cs
+++ b/src/ScottPlot.Demo.WinForms/FormDemos.Designer.cs
@@ -72,8 +72,8 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(249, 47);
             this.label2.TabIndex = 3;
-            this.label2.Text = "Demonstrate that setting formsPlot1.BackColor also sets the plot figure backgroun" +
-    "d";
+            this.label2.Text = "Demonstrate a transparent ScottPlot control that lets you see through to the back" +
+    "ground of the form";
             // 
             // FormDemos
             // 

--- a/src/ScottPlot.Demo.WinForms/FormDemos.Designer.cs
+++ b/src/ScottPlot.Demo.WinForms/FormDemos.Designer.cs
@@ -30,6 +30,8 @@
         {
             this.MouseTrackerButton = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
+            this.TransparentBackgroundButton = new System.Windows.Forms.Button();
+            this.label2 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // MouseTrackerButton
@@ -52,11 +54,34 @@
             this.label1.TabIndex = 1;
             this.label1.Text = "Display mouse position in pixel coordinates and graph coordinates.";
             // 
+            // TransparentBackgroundButton
+            // 
+            this.TransparentBackgroundButton.Location = new System.Drawing.Point(12, 65);
+            this.TransparentBackgroundButton.Name = "TransparentBackgroundButton";
+            this.TransparentBackgroundButton.Size = new System.Drawing.Size(75, 47);
+            this.TransparentBackgroundButton.TabIndex = 2;
+            this.TransparentBackgroundButton.Text = "Transparent Background";
+            this.TransparentBackgroundButton.UseVisualStyleBackColor = true;
+            this.TransparentBackgroundButton.Click += new System.EventHandler(this.TransparentBackgroundButton_Click);
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label2.Location = new System.Drawing.Point(93, 65);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(249, 47);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Demonstrate that setting formsPlot1.BackColor also sets the plot figure backgroun" +
+    "d";
+            // 
             // FormDemos
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(354, 249);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.TransparentBackgroundButton);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.MouseTrackerButton);
             this.Name = "FormDemos";
@@ -69,5 +94,7 @@
 
         private System.Windows.Forms.Button MouseTrackerButton;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button TransparentBackgroundButton;
+        private System.Windows.Forms.Label label2;
     }
 }

--- a/src/ScottPlot.Demo.WinForms/FormDemos.cs
+++ b/src/ScottPlot.Demo.WinForms/FormDemos.cs
@@ -21,5 +21,10 @@ namespace ScottPlot.Demo.WinForms
         {
             new WinFormsDemos.MouseTracker().ShowDialog();
         }
+
+        private void TransparentBackgroundButton_Click(object sender, EventArgs e)
+        {
+            new WinFormsDemos.TransparentBackground().ShowDialog();
+        }
     }
 }

--- a/src/ScottPlot.Demo.WinForms/ScottPlot.Demo.WinForms.csproj
+++ b/src/ScottPlot.Demo.WinForms/ScottPlot.Demo.WinForms.csproj
@@ -81,6 +81,12 @@
     <Compile Include="WinFormsDemos\MouseTracker.Designer.cs">
       <DependentUpon>MouseTracker.cs</DependentUpon>
     </Compile>
+    <Compile Include="WinFormsDemos\TransparentBackground.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="WinFormsDemos\TransparentBackground.Designer.cs">
+      <DependentUpon>TransparentBackground.cs</DependentUpon>
+    </Compile>
     <EmbeddedResource Include="FormCookbook.resx">
       <DependentUpon>FormCookbook.cs</DependentUpon>
     </EmbeddedResource>
@@ -101,6 +107,9 @@
     </Compile>
     <EmbeddedResource Include="WinFormsDemos\MouseTracker.resx">
       <DependentUpon>MouseTracker.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="WinFormsDemos\TransparentBackground.resx">
+      <DependentUpon>TransparentBackground.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.Designer.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.Designer.cs
@@ -1,0 +1,138 @@
+﻿namespace ScottPlot.Demo.WinForms.WinFormsDemos
+{
+    partial class TransparentBackground
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.button3 = new System.Windows.Forms.Button();
+            this.formsPlot1 = new ScottPlot.FormsPlot();
+            this.button4 = new System.Windows.Forms.Button();
+            this.button5 = new System.Windows.Forms.Button();
+            this.button6 = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(12, 12);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "red";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(93, 12);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.TabIndex = 1;
+            this.button2.Text = "green";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
+            // 
+            // button3
+            // 
+            this.button3.Location = new System.Drawing.Point(174, 12);
+            this.button3.Name = "button3";
+            this.button3.Size = new System.Drawing.Size(75, 23);
+            this.button3.TabIndex = 2;
+            this.button3.Text = "blue";
+            this.button3.UseVisualStyleBackColor = true;
+            this.button3.Click += new System.EventHandler(this.button3_Click);
+            // 
+            // formsPlot1
+            // 
+            this.formsPlot1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.formsPlot1.Location = new System.Drawing.Point(12, 41);
+            this.formsPlot1.Name = "formsPlot1";
+            this.formsPlot1.Size = new System.Drawing.Size(599, 275);
+            this.formsPlot1.TabIndex = 3;
+            // 
+            // button4
+            // 
+            this.button4.Location = new System.Drawing.Point(255, 12);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(75, 23);
+            this.button4.TabIndex = 4;
+            this.button4.Text = "white";
+            this.button4.UseVisualStyleBackColor = true;
+            this.button4.Click += new System.EventHandler(this.button4_Click);
+            // 
+            // button5
+            // 
+            this.button5.Location = new System.Drawing.Point(336, 12);
+            this.button5.Name = "button5";
+            this.button5.Size = new System.Drawing.Size(75, 23);
+            this.button5.TabIndex = 5;
+            this.button5.Text = "control";
+            this.button5.UseVisualStyleBackColor = true;
+            this.button5.Click += new System.EventHandler(this.button5_Click);
+            // 
+            // button6
+            // 
+            this.button6.Location = new System.Drawing.Point(417, 12);
+            this.button6.Name = "button6";
+            this.button6.Size = new System.Drawing.Size(75, 23);
+            this.button6.TabIndex = 6;
+            this.button6.Text = "image";
+            this.button6.UseVisualStyleBackColor = true;
+            this.button6.Click += new System.EventHandler(this.button6_Click);
+            // 
+            // TransparentBackground
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(623, 328);
+            this.Controls.Add(this.button6);
+            this.Controls.Add(this.button5);
+            this.Controls.Add(this.button4);
+            this.Controls.Add(this.formsPlot1);
+            this.Controls.Add(this.button3);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button1);
+            this.Name = "TransparentBackground";
+            this.Text = "Transparent Background";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.Button button3;
+        private FormsPlot formsPlot1;
+        private System.Windows.Forms.Button button4;
+        private System.Windows.Forms.Button button5;
+        private System.Windows.Forms.Button button6;
+    }
+}

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
@@ -15,9 +15,9 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         public TransparentBackground()
         {
             InitializeComponent();
-
             GenericPlots.SinAndCos(formsPlot1.plt);
-            formsPlot1.plt.Style(figBg: Color.Transparent);
+            formsPlot1.plt.Style(figBg: Color.Transparent, dataBg: Color.Transparent);
+            formsPlot1.BackColor = Color.Transparent;
             button1_Click(null, null);
         }
 
@@ -48,19 +48,21 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
 
         private void button6_Click(object sender, EventArgs e)
         {
+            // apply a Bitmap to the background of this form
             Random rand = new Random();
             Bitmap bmp = new Bitmap(200, 200);
             Graphics gfx = Graphics.FromImage(bmp);
             gfx.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
-            gfx.Clear(Color.DarkBlue);
-            Brush brsh = new SolidBrush(Color.LightBlue);
-            Size circleSize = new Size(10, 10);
+            gfx.Clear(SystemColors.Control);
+            Pen pen = Pens.LightGray;
+            Size circleSize = new Size(20, 20);
             for (int i=0; i<100; i++)
             {
                 Point randomPoint = new Point(rand.Next(bmp.Width - circleSize.Width), rand.Next(bmp.Height - circleSize.Height));
                 Rectangle rect = new Rectangle(randomPoint, circleSize);
-                gfx.FillEllipse(brsh, rect);
+                gfx.DrawEllipse(pen, rect);
             }
+
             BackgroundImage = bmp;
         }
 
@@ -68,7 +70,6 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         {
             BackgroundImage = null;
             BackColor = bgcolor;
-            formsPlot1.BackColor = bgcolor;
             formsPlot1.Render();
         }
     }

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
@@ -18,7 +18,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             GenericPlots.SinAndCos(formsPlot1.plt);
             formsPlot1.plt.Style(figBg: Color.Transparent, dataBg: Color.Transparent);
             formsPlot1.BackColor = Color.Transparent;
-            button1_Click(null, null);
+            button6_Click(null, null);
         }
 
         private void button1_Click(object sender, EventArgs e)
@@ -64,6 +64,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             }
 
             BackgroundImage = bmp;
+            formsPlot1.Render();
         }
 
         private void SetBackground(Color bgcolor)

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ScottPlot.Demo.WinForms.WinFormsDemos
+{
+    public partial class TransparentBackground : Form
+    {
+        public TransparentBackground()
+        {
+            InitializeComponent();
+
+            GenericPlots.SinAndCos(formsPlot1.plt);
+            formsPlot1.plt.Style(figBg: Color.Transparent);
+            button1_Click(null, null);
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            SetBackground(Color.Red);
+        }
+
+        private void button2_Click(object sender, EventArgs e)
+        {
+            SetBackground(Color.Green);
+        }
+
+        private void button3_Click(object sender, EventArgs e)
+        {
+            SetBackground(Color.Blue);
+        }
+
+        private void button4_Click(object sender, EventArgs e)
+        {
+            SetBackground(Color.White);
+        }
+
+        private void button5_Click(object sender, EventArgs e)
+        {
+            SetBackground(SystemColors.Control);
+        }
+
+        private void button6_Click(object sender, EventArgs e)
+        {
+            Random rand = new Random();
+            Bitmap bmp = new Bitmap(200, 200);
+            Graphics gfx = Graphics.FromImage(bmp);
+            gfx.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            gfx.Clear(Color.DarkBlue);
+            Brush brsh = new SolidBrush(Color.LightBlue);
+            Size circleSize = new Size(10, 10);
+            for (int i=0; i<100; i++)
+            {
+                Point randomPoint = new Point(rand.Next(bmp.Width - circleSize.Width), rand.Next(bmp.Height - circleSize.Height));
+                Rectangle rect = new Rectangle(randomPoint, circleSize);
+                gfx.FillEllipse(brsh, rect);
+            }
+            BackgroundImage = bmp;
+        }
+
+        private void SetBackground(Color bgcolor)
+        {
+            BackgroundImage = null;
+            BackColor = bgcolor;
+            formsPlot1.BackColor = bgcolor;
+            formsPlot1.Render();
+        }
+    }
+}

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.resx
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -15,6 +15,16 @@ namespace ScottPlot
         public Cursor cursor = Cursors.Arrow;
         ContextMenuStrip rightClickMenu;
 
+        public override Color BackColor
+        {
+            get => base.BackColor;
+            set
+            {
+                base.BackColor = value;
+                pbPlot.BackColor = value;
+            }
+        }
+
         public FormsPlot(Plot plt)
         {
             InitializeComponent();

--- a/tests/Cookbook/Chef.cs
+++ b/tests/Cookbook/Chef.cs
@@ -10,12 +10,20 @@ namespace ScottPlotTests.Cookbook
         [Test]
         public void Test_Cookbook_MakeCookbook()
         {
+            // don't run test on MacOS
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+                return; // TODO: figure out how to get this working in MacOS
+
             ScottPlot.Demo.Cookbook.Chef.MakeCookbook("../../../../src/ScottPlot.Demo/");
         }
 
         [Test]
         public void Test_Cookbook_ReadRecipes()
         {
+            // don't run test on MacOS
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+                return; // TODO: figure out how to get this working in MacOS
+
             ScottPlot.Demo.IPlotDemo[] recipes = ScottPlot.Demo.Reflection.GetPlots();
 
             foreach(var recipe in recipes)

--- a/tests/Cookbook/Chef.cs
+++ b/tests/Cookbook/Chef.cs
@@ -12,14 +12,5 @@ namespace ScottPlotTests.Cookbook
         {
             ScottPlot.Demo.Cookbook.Chef.MakeCookbook("../../../../src/ScottPlot.Demo/");
         }
-
-        [Test]
-        public void Test_Cookbook_ReadRecipes()
-        {
-            ScottPlot.Demo.IPlotDemo[] recipes = ScottPlot.Demo.Reflection.GetPlots();
-
-            foreach(var recipe in recipes)
-                Console.WriteLine(recipe.id);
-        }
     }
 }

--- a/tests/Cookbook/Chef.cs
+++ b/tests/Cookbook/Chef.cs
@@ -12,5 +12,14 @@ namespace ScottPlotTests.Cookbook
         {
             ScottPlot.Demo.Cookbook.Chef.MakeCookbook("../../../../src/ScottPlot.Demo/");
         }
+
+        [Test]
+        public void Test_Cookbook_ReadRecipes()
+        {
+            ScottPlot.Demo.IPlotDemo[] recipes = ScottPlot.Demo.Reflection.GetPlots();
+
+            foreach(var recipe in recipes)
+                Console.WriteLine(recipe.id);
+        }
     }
 }


### PR DESCRIPTION
This PR allow user to set `formsPlot.BackColor = Color.Transparent` and get transparency over `Form` `BackGroundImage` #286.
Transparency over other controls requires a more complex solution (https://github.com/swharden/ScottPlot/issues/286#issuecomment-596084208)