### PR TITLE
Fix wrong span calculation

### DIFF
--- a/src/ScottPlot/Statistics/Regression.cs
+++ b/src/ScottPlot/Statistics/Regression.cs
@@ -47,7 +47,7 @@ namespace ScottPlot.Statistics
             double meanY = ys.Average();
             double sumXYResidual = 0;
             double sumXSquareResidual = 0;
-            double spanX = firstX + pointCount * xSpacing;
+            double spanX = (pointCount - 1) * xSpacing;
             double meanX = spanX / 2 + firstX;
 
             for (int i = 0; i < pointCount; i++)

--- a/tests/RegressionTests.cs
+++ b/tests/RegressionTests.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ScottPlot.Statistics;
+
+namespace ScottPlotTests
+{
+    [TestFixture]
+    public class RegressionTests
+    {
+        // Issue #290 Test
+        [Test]
+        public void GetCoefficients_FirstXNotZero_ResultEqualtoTI_84_Plus()
+        {
+            double[] x = new double[] { 1, 2, 3, 4, 5, 6, 7 };
+            double[] y = new double[] { 2, 2, 3, 3, 3.8, 4.2, 4 };
+            var reg = new LinearRegressionLine(x, y);
+            Assert.AreEqual(0.4, reg.slope, 0.0001);
+            Assert.AreEqual(1.5428, reg.offset, 0.0001);
+        }
+    }
+}


### PR DESCRIPTION
This PR fix wrong span calculation in LinearRegressionLine #290.
@Benny121221 make more usefull PR #291, which also fix this bug and allow LineRegression for not evently space data.
At least you can grab test from this PR.