### PR TITLE
Tools.ConvertPolarCoordinates()

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -45,6 +45,7 @@ _ScottPlot uses [semantic](https://semver.org/) (major.minor.patch) versioning. 
 * Made all `Plot.Axis` methods return axis limits as `double[]` (previously many of them returned `void`)
 * Added overload for `Plot.PlotLine()` which accepts a slope, offset, and start and end X points to make it easy to plot a linear line with known formula. Using PlotFormula() will produce the same output, but this may be simpler to use for straight lines.
 * Added `rSquared` property to linear regression fits (#290) _Thanks @Benny121221 and @StendProg_
+* Added `Tools.ConvertPolarCoordinates()` to make it easier to display polar data on ScottPlot's Cartesian axes (#298) _Thanks @Benny121221_
 
 ## ScottPlot 4.0.19
 

--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -71,5 +71,33 @@ namespace ScottPlot.Demo.Customize
                 plt.XLabel("Horizontal Units");
             }
         }
+
+        public class PolarAxis : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Polar Axis";
+            public string description { get; } = "";
+
+            public void Render(Plot plt)
+            {
+                int count = 400;
+                double step = 0.01;
+
+                double[] dataR = new double[count];
+                double[] dataTheta = new double[count];
+                double[] dataX = new double[count];
+                double[] dataY = new double[count];
+
+                for (int i = 0; i < dataR.Length; i++)
+                {
+                    dataR[i] = 1 + (double)i * step;
+                    dataTheta[i] = i * 2 * Math.PI * step;
+                }
+
+                (dataX, dataY) = ScottPlot.Tools.ConvertPolarCoordinates(dataR, dataTheta);
+
+                plt.PlotScatter(dataX, dataY);
+                plt.Title("Data (Polar Scale)");
+            }
+        }
     }
 }

--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -79,24 +79,25 @@ namespace ScottPlot.Demo.Customize
 
             public void Render(Plot plt)
             {
+                // create some data with polar coordinates
                 int count = 400;
                 double step = 0.01;
 
-                double[] dataR = new double[count];
-                double[] dataTheta = new double[count];
-                double[] dataX = new double[count];
-                double[] dataY = new double[count];
+                double[] rs = new double[count];
+                double[] thetas = new double[count];
 
-                for (int i = 0; i < dataR.Length; i++)
+                for (int i = 0; i < rs.Length; i++)
                 {
-                    dataR[i] = 1 + (double)i * step;
-                    dataTheta[i] = i * 2 * Math.PI * step;
+                    rs[i] = 1 + i * step;
+                    thetas[i] = i * 2 * Math.PI * step;
                 }
 
-                (dataX, dataY) = ScottPlot.Tools.ConvertPolarCoordinates(dataR, dataTheta);
+                // convert polar data to Cartesian data
+                (double[] xs, double[] ys) = ScottPlot.Tools.ConvertPolarCoordinates(rs, thetas);
 
-                plt.PlotScatter(dataX, dataY);
-                plt.Title("Data (Polar Scale)");
+                // plot the Cartesian data
+                plt.PlotScatter(xs, ys);
+                plt.Title("Scatter Plot of Polar Data");
             }
         }
     }

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -226,7 +226,7 @@ namespace ScottPlot
             return dataOut;
         }
 
-        public static (double[], double[]) ConvertPolarCoordinates(double[] rs, double[] thetas) {
+        public static (double[] xs, double[] ys) ConvertPolarCoordinates(double[] rs, double[] thetas) {
             double[] xs = new double[rs.Length];
             double[] ys = new double[rs.Length];
 

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -226,6 +226,22 @@ namespace ScottPlot
             return dataOut;
         }
 
+        public static (double[], double[]) ConvertPolarCoordinates(double[] rs, double[] thetas) {
+            double[] xs = new double[rs.Length];
+            double[] ys = new double[rs.Length];
+
+            for (int i = 0; i < rs.Length; i++)
+            {
+                double x = rs[i];
+                double y = thetas[i];
+
+                xs[i] = x * Math.Cos(y);
+                ys[i] = x * Math.Sin(y);
+            }
+
+            return (xs, ys);
+        }
+
         public static void LaunchBrowser(string url = "http://swharden.com/scottplot/")
         {
             // A cross-platform .NET-Core-safe function to launch a URL in the browser


### PR DESCRIPTION
This time the conversion is done in `src/ScottPlot/Tools.cs`, not in the PlotScatter function. The only thing is this returns a tuple, I would be happy to change the return type if you feel like that would better reflect the direction of the project.