### PR TITLE
Easier function plotting

### DIFF
--- a/src/ScottPlot.Demo/PlotTypes/Function.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Function.cs
@@ -9,9 +9,7 @@ namespace ScottPlot.Demo.PlotTypes
         public class Quickstart : PlotDemo, IPlotDemo
         {
             public string name { get; } = "Function Plot";
-            public string description { get; } = "A function (not data points) is provided to create this plot. Axes can be zoomed infinitely. " +
-                "For functions with a restricted domain, you should return null to prevent errors.\n\n" +
-                "e.g. new Func<double, double?>((x) => x > 0 ? Math.Log(x) : (double?)null);";
+            public string description { get; } = "A function (not data points) is provided to create this plot. Axes can be zoomed infinitely.";
 
             public void Render(Plot plt)
             {

--- a/src/ScottPlot/plottables/PlottableFunction.cs
+++ b/src/ScottPlot/plottables/PlottableFunction.cs
@@ -75,7 +75,7 @@ namespace ScottPlot
                     continue;
                 }
 
-                if (y.HasValue)
+                if (y.HasValue && !double.IsNaN(y.Value))
                 {
                     xList.Add(x);
                     yList.Add(y.Value);

--- a/src/ScottPlot/plottables/PlottableFunction.cs
+++ b/src/ScottPlot/plottables/PlottableFunction.cs
@@ -75,8 +75,11 @@ namespace ScottPlot
                     continue;
                 }
 
-                if (y.HasValue && !double.IsNaN(y.Value))
+                if (y.HasValue)
                 {
+                    if (double.IsNaN(y.Value) || double.IsInfinity(y.Value)) {// double.IsInfinity checks for positive or negative infinity
+                        continue;
+                    }
                     xList.Add(x);
                     yList.Add(y.Value);
                 }


### PR DESCRIPTION
New contributors should review CONTRIBUTING.md:
https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md

**Purpose:**
This makes plotting functions with restricted domain easier.

**New functionality (code):**
Previously, if I wanted to plot the function `ln x`, I would have to do it like this:

`x => x > 0 ? Math.Log(x) : (double?)null`

Now I can just do `x => Math.Log(x)` and it will be taken care of.