### PR TITLE
Fix loosing control focus on alt key press.

### DIFF
--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -45,11 +45,8 @@ namespace ScottPlot
             Application.AddMessageFilter(this);
             Reset(plt);
         }
-        public FormsPlot()
+        public FormsPlot() : this(null)
         {
-            InitializeComponent();
-            Application.AddMessageFilter(this);
-            Reset(null);
         }
 
         public void Reset()

--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -47,6 +47,7 @@ namespace ScottPlot
         }
         public FormsPlot() : this(null)
         {
+            Application.AddMessageFilter(this);
         }
 
         public void Reset()

--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -1,13 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
-using System.Diagnostics;
-using System.ComponentModel;
 
 namespace ScottPlot
 {
 
-    public partial class FormsPlot : UserControl
+    public partial class FormsPlot : UserControl, IMessageFilter
     {
         public Plot plt { get; private set; }
         private Settings settings;
@@ -24,15 +23,32 @@ namespace ScottPlot
             }
         }
 
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            Application.RemoveMessageFilter(this);
+            base.OnHandleDestroyed(e);
+        }
+        public bool PreFilterMessage(ref Message m)
+        {
+            // Trap WM_SYSKEYUPDOWN message for the ALT key
+            if ((Keys)m.WParam.ToInt64() == Keys.Menu)
+            {
+                if (m.Msg == 0x104) { return true; }
+                if (m.Msg == 0x105) { return true; }
+            }
+            return false;
+        }
+
         public FormsPlot(Plot plt)
         {
             InitializeComponent();
+            Application.AddMessageFilter(this);
             Reset(plt);
         }
-
         public FormsPlot()
         {
             InitializeComponent();
+            Application.AddMessageFilter(this);
             Reset(null);
         }
 


### PR DESCRIPTION
**Purpose:**
Pressing the Alt Key in a WinForms Application Loses the Focus of the Control. #436
This PR filter all `alt` key windows messages, and prevent application to catch that.
Solution taken from the discussion of this problem:
https://stackoverflow.com/questions/18235781/how-do-i-prevent-the-control-box-getting-focus-when-i-press-alt/18235868#18235868
> Beware of the many side effects, it stops a menu behaving normally and shortcut keystrokes that use Alt are not going to work anymore. Do consider using Ctrl or Shift instead.


Additionaly a small fix to remove duplicate code in the Winform user control constructors.