### PR TITLE
Fix lag on linked axes.

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,5 +1,8 @@
 # ScottPlot Changelog
 
+## ScottPlot 4.0.37
+* Added `processEvents` argument to `formsPlot2.Render()` to provide a performance enhancement when linking axes of two `FormsPlot` controls together (by calling `Plot.MatchAxis()` from the control's `AxesChanged` event, as seen in the _Linked Axes_ demo application) (#451, #452) _Thanks @StendProg and @robokamran_
+
 ## ScottPlot 4.0.36
 * `PlotScatterHighlight()` was created as a type of scatter plot designed specifically for applications where "show value on hover" functionality is desired. Examples are both in the cookbook and WinForms and WPF demo applications. (#415, #414) _Thanks @Benny121221 and @StendProg_
 * `PlotRadar()` is a new plot type for creating Radar plots (also called spider plots or star plots). See cookbook and demo application for examples. (#428, #430) _Thanks @Benny121221_

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.Designer.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.Designer.cs
@@ -28,25 +28,29 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.formsPlot1 = new ScottPlot.FormsPlot();
             this.formsPlot2 = new ScottPlot.FormsPlot();
+            this.cbProcessEvents = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.ColumnCount = 1;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.Controls.Add(this.formsPlot1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.formsPlot2, 0, 1);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 35);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(659, 406);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(635, 359);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // formsPlot1
@@ -54,24 +58,35 @@
             this.formsPlot1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.formsPlot1.Location = new System.Drawing.Point(3, 3);
             this.formsPlot1.Name = "formsPlot1";
-            this.formsPlot1.Size = new System.Drawing.Size(653, 197);
+            this.formsPlot1.Size = new System.Drawing.Size(629, 173);
             this.formsPlot1.TabIndex = 0;
             this.formsPlot1.AxesChanged += new System.EventHandler(this.formsPlot1_AxesChanged);
             // 
             // formsPlot2
             // 
             this.formsPlot2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.formsPlot2.Location = new System.Drawing.Point(3, 206);
+            this.formsPlot2.Location = new System.Drawing.Point(3, 182);
             this.formsPlot2.Name = "formsPlot2";
-            this.formsPlot2.Size = new System.Drawing.Size(653, 197);
+            this.formsPlot2.Size = new System.Drawing.Size(629, 174);
             this.formsPlot2.TabIndex = 1;
             this.formsPlot2.AxesChanged += new System.EventHandler(this.formsPlot2_AxesChanged);
+            // 
+            // cbProcessEvents
+            // 
+            this.cbProcessEvents.AutoSize = true;
+            this.cbProcessEvents.Location = new System.Drawing.Point(15, 12);
+            this.cbProcessEvents.Name = "cbProcessEvents";
+            this.cbProcessEvents.Size = new System.Drawing.Size(98, 17);
+            this.cbProcessEvents.TabIndex = 1;
+            this.cbProcessEvents.Text = "process events";
+            this.cbProcessEvents.UseVisualStyleBackColor = true;
             // 
             // LinkedPlots
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(659, 406);
+            this.Controls.Add(this.cbProcessEvents);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "LinkedPlots";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
@@ -79,6 +94,7 @@
             this.Load += new System.EventHandler(this.LinkedPlots_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -87,5 +103,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private FormsPlot formsPlot1;
         private FormsPlot formsPlot2;
+        private System.Windows.Forms.CheckBox cbProcessEvents;
     }
 }

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.Designer.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.Designer.cs
@@ -30,9 +30,9 @@
         {
             this.components = new System.ComponentModel.Container();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.cbProcessEvents = new System.Windows.Forms.CheckBox();
             this.formsPlot1 = new ScottPlot.FormsPlot();
             this.formsPlot2 = new ScottPlot.FormsPlot();
-            this.cbProcessEvents = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -53,6 +53,18 @@
             this.tableLayoutPanel1.Size = new System.Drawing.Size(635, 359);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
+            // cbProcessEvents
+            // 
+            this.cbProcessEvents.AutoSize = true;
+            this.cbProcessEvents.Checked = true;
+            this.cbProcessEvents.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbProcessEvents.Location = new System.Drawing.Point(15, 12);
+            this.cbProcessEvents.Name = "cbProcessEvents";
+            this.cbProcessEvents.Size = new System.Drawing.Size(98, 17);
+            this.cbProcessEvents.TabIndex = 1;
+            this.cbProcessEvents.Text = "process events";
+            this.cbProcessEvents.UseVisualStyleBackColor = true;
+            // 
             // formsPlot1
             // 
             this.formsPlot1.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -70,16 +82,6 @@
             this.formsPlot2.Size = new System.Drawing.Size(629, 174);
             this.formsPlot2.TabIndex = 1;
             this.formsPlot2.AxesChanged += new System.EventHandler(this.formsPlot2_AxesChanged);
-            // 
-            // cbProcessEvents
-            // 
-            this.cbProcessEvents.AutoSize = true;
-            this.cbProcessEvents.Location = new System.Drawing.Point(15, 12);
-            this.cbProcessEvents.Name = "cbProcessEvents";
-            this.cbProcessEvents.Size = new System.Drawing.Size(98, 17);
-            this.cbProcessEvents.TabIndex = 1;
-            this.cbProcessEvents.Text = "process events";
-            this.cbProcessEvents.UseVisualStyleBackColor = true;
             // 
             // LinkedPlots
             // 

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
@@ -20,7 +20,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         private void LinkedPlots_Load(object sender, EventArgs e)
         {
             Random rand = new Random(0);
-            int pointCount = 500;
+            int pointCount = 5000;
             double[] dataXs = DataGen.Consecutive(pointCount);
             double[] dataSin = DataGen.NoisySin(rand, pointCount);
             double[] dataCos = DataGen.NoisySin(rand, pointCount);
@@ -35,15 +35,13 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         private void formsPlot1_AxesChanged(object sender, EventArgs e)
         {
             formsPlot2.plt.MatchAxis(formsPlot1.plt);
-            formsPlot2.Render(true, processEvents: true);
+            formsPlot2.Render(skipIfCurrentlyRendering: true, processEvents: cbProcessEvents.Checked);
         }
 
         private void formsPlot2_AxesChanged(object sender, EventArgs e)
         {
             formsPlot1.plt.MatchAxis(formsPlot2.plt);
-            // TODO this not optimal Render for demonstration only, swap with commented at final!
-            formsPlot1.Render();
-            //formsPlot1.Render(true, processEvents: true);
+            formsPlot1.Render(skipIfCurrentlyRendering: true, processEvents: cbProcessEvents.Checked);
         }
     }
 }

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
@@ -19,10 +19,11 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
 
         private void LinkedPlots_Load(object sender, EventArgs e)
         {
-            int pointCount = 51;
+            Random rand = new Random(0);
+            int pointCount = 500;
             double[] dataXs = DataGen.Consecutive(pointCount);
-            double[] dataSin = DataGen.Sin(pointCount);
-            double[] dataCos = DataGen.Cos(pointCount);
+            double[] dataSin = DataGen.NoisySin(rand, pointCount);
+            double[] dataCos = DataGen.NoisySin(rand, pointCount);
 
             formsPlot1.plt.PlotScatter(dataXs, dataSin);
             formsPlot1.Render();

--- a/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
+++ b/src/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
@@ -34,13 +34,15 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         private void formsPlot1_AxesChanged(object sender, EventArgs e)
         {
             formsPlot2.plt.MatchAxis(formsPlot1.plt);
-            formsPlot2.Render();
+            formsPlot2.Render(true, processEvents: true);
         }
 
         private void formsPlot2_AxesChanged(object sender, EventArgs e)
         {
             formsPlot1.plt.MatchAxis(formsPlot2.plt);
+            // TODO this not optimal Render for demonstration only, swap with commented at final!
             formsPlot1.Render();
+            //formsPlot1.Render(true, processEvents: true);
         }
     }
 }

--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -91,7 +91,7 @@ namespace ScottPlot
         }
 
         private bool currentlyRendering;
-        public void Render(bool skipIfCurrentlyRendering = false, bool lowQuality = false, bool recalculateLayout = false)
+        public void Render(bool skipIfCurrentlyRendering = false, bool lowQuality = false, bool recalculateLayout = false, bool processEvents = false)
         {
             if (isDesignerMode)
                 return;
@@ -106,7 +106,7 @@ namespace ScottPlot
             {
                 currentlyRendering = true;
                 pbPlot.Image = plt?.GetBitmap(true, lowQuality);
-                if (isPanningOrZooming || isMovingDraggable)
+                if (isPanningOrZooming || isMovingDraggable || processEvents)
                     Application.DoEvents();
                 currentlyRendering = false;
                 Rendered?.Invoke(this, EventArgs.Empty);

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -2050,7 +2050,7 @@ namespace ScottPlot
                 settings.axes.y.min = sourcePlot.settings.axes.y.min;
                 settings.axes.y.max = sourcePlot.settings.axes.y.max;
             }
-            Resize();
+            //Resize();
         }
 
         // TODO: create a new Style()

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -2050,7 +2050,7 @@ namespace ScottPlot
                 settings.axes.y.min = sourcePlot.settings.axes.y.min;
                 settings.axes.y.max = sourcePlot.settings.axes.y.max;
             }
-            //Resize();
+            TightenLayout();
         }
 
         // TODO: create a new Style()


### PR DESCRIPTION
**Purpose:**
Fix linked axes lagging. #451 
The reasone is full `Render()` loop in second `formsPlot` on each mouse move.
This PR add `skipIfCurrentRendered = true` to demo,
Add extra param to `Render(bool processEvents)`. This param allow to make `Application.DoEvents()` in `Render()` for not interactive formsPlot (no mouse pan on zoom).

`Resize()` in `MatchAxis()` was commented. I have no idea why it was implemented in this method, But it create new bitmaps for all layers on each `MatchAxis()` call.

//TODO
Demo contain not optimal render call in `formsPlot2.AxisChanged()`.
This is for demonstration benefits of this PR. It must be changed to optimal before merge.

**New functionality (code):**
Extra parameter in `Render()` to process events in not interacted `formsPlot`.
Combined with `skipIfCurrentlyRendered=true` this allow multiple Render calls without lagging for not interactive `formsPlots`. This param may be usefull not only for linked axes plots.
```cs
formsPlot.Render(true, true, processEvents: true)
```

**New functionality (image):**
Linked Axes demo demonstrates this PR.
Interactions on upper `formsPlot1` contain this PR changes.
Interactions on lower  `formsPlot2` use old implementation. 