### PR TITLE
Signal RenderHighDensity fix and refactor

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,5 +1,8 @@
 # ScottPlot Changelog
 
+## ScottPlot 4.0.36 ⚠️ _in active development_
+* Signal plots now have an optional `useParallel` argument (and property) to allow the user to decide whether parallel or sequential calculations will be performed. (#454, #419, #245, #72) _Thanks @StendProg_
+
 ## ScottPlot 4.0.35
 * Added `processEvents` argument to `formsPlot2.Render()` to provide a performance enhancement when linking axes of two `FormsPlot` controls together (by calling `Plot.MatchAxis()` from the control's `AxesChanged` event, as seen in the _Linked Axes_ demo application) (#451, #452) _Thanks @StendProg and @robokamran_
 * New `Plot.PlotVectorField()` method for displaying vector fields (sometimes called quiver plots) (#438, #439, #440) _Thanks @Benny121221 and @hhubschle_

--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,7 +1,7 @@
 # ScottPlot Changelog
 
 ## ScottPlot 4.0.36 ⚠️ _in active development_
-* Signal plots now have an optional `useParallel` argument (and property) to allow the user to decide whether parallel or sequential calculations will be performed. (#454, #419, #245, #72) _Thanks @StendProg_
+* `PlotSignal()` and `PlotSignalXY()` plots now have an optional `useParallel` argument (and public property on the objects they return) to allow the user to decide whether parallel or sequential calculations will be performed. (#454, #419, #245, #72) _Thanks @StendProg_
 
 ## ScottPlot 4.0.35
 * Added `processEvents` argument to `formsPlot2.Render()` to provide a performance enhancement when linking axes of two `FormsPlot` controls together (by calling `Plot.MatchAxis()` from the control's `AxesChanged` event, as seen in the _Linked Axes_ demo application) (#451, #452) _Thanks @StendProg and @robokamran_

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -961,7 +961,8 @@ namespace ScottPlot
             string label = null,
             Color[] colorByDensity = null,
             int? maxRenderIndex = null,
-            LineStyle lineStyle = LineStyle.Solid
+            LineStyle lineStyle = LineStyle.Solid,
+            bool useParallel = true
             )
         {
             if (color == null)
@@ -981,7 +982,8 @@ namespace ScottPlot
                 label: label,
                 colorByDensity: colorByDensity,
                 maxRenderIndex: (int)maxRenderIndex,
-                lineStyle: lineStyle
+                lineStyle: lineStyle,
+                useParallel: true
                 );
 
             settings.plottables.Add(signal);

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -926,7 +926,8 @@ namespace ScottPlot
             double markerSize = 5,
             string label = null,
             int? maxRenderIndex = null,
-            LineStyle lineStyle = LineStyle.Solid
+            LineStyle lineStyle = LineStyle.Solid,
+            bool useParallel = true
             )
         {
             if (color == null)
@@ -943,7 +944,8 @@ namespace ScottPlot
                 markerSize: markerSize,
                 label: label,
                 maxRenderIndex: (int)maxRenderIndex,
-                lineStyle: lineStyle
+                lineStyle: lineStyle,
+                useParallel: useParallel
                 );
 
             settings.plottables.Add(signal);
@@ -983,7 +985,7 @@ namespace ScottPlot
                 colorByDensity: colorByDensity,
                 maxRenderIndex: (int)maxRenderIndex,
                 lineStyle: lineStyle,
-                useParallel: true
+                useParallel: useParallel
                 );
 
             settings.plottables.Add(signal);

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -1,11 +1,11 @@
-﻿using ScottPlot.Config;
-using ScottPlot.Drawing;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using ScottPlot.Config;
+using ScottPlot.Drawing;
 
 namespace ScottPlot
 {

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -170,10 +170,6 @@ namespace ScottPlot
             if (index2 > ys.Length - 1)
                 index2 = ys.Length - 1;
 
-            if (index1 > maxRenderIndex)
-            {
-                return null;
-            }
             if (index2 > maxRenderIndex)
                 index2 = maxRenderIndex;
 
@@ -191,10 +187,11 @@ namespace ScottPlot
             float yPxLow = (float)settings.GetPixelY(highestValue + yOffset);
             return new IntervalMinMax(xPx, yPxLow, yPxHigh);
         }
+
         private void RenderHighDensity(Settings settings, double offsetPoints, double columnPointCount)
         {
             int xPxStart = (int)Math.Ceiling((-1 - offsetPoints) / columnPointCount - 1);
-            int xPxEnd = (int)Math.Ceiling((ys.Length - offsetPoints) / columnPointCount);
+            int xPxEnd = (int)Math.Ceiling((maxRenderIndex - offsetPoints) / columnPointCount);
             xPxStart = Math.Max(0, xPxStart);
             xPxEnd = Math.Min(settings.dataSize.Width, xPxEnd);
             if (xPxStart >= xPxEnd)
@@ -209,14 +206,12 @@ namespace ScottPlot
                     .AsParallel()
                     .AsOrdered()
                     .Select(xPx => CalcInterval(xPx, offsetPoints, columnPointCount, settings))
-                    .Where(x => x != null)
                     .AsSequential();
             }
             else
             {
                 intervals = columns
-                    .Select(xPx => CalcInterval(xPx, offsetPoints, columnPointCount, settings))
-                    .Where(x => x != null);
+                    .Select(xPx => CalcInterval(xPx, offsetPoints, columnPointCount, settings));
             }
 
             PointF[] linePoints = intervals

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -30,7 +30,7 @@ namespace ScottPlot
         public LineStyle lineStyle;
         public bool useParallel = true;
 
-        public PlottableSignal(double[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, Color[] colorByDensity, int maxRenderIndex, LineStyle lineStyle)
+        public PlottableSignal(double[] ys, double sampleRate, double xOffset, double yOffset, Color color, double lineWidth, double markerSize, string label, Color[] colorByDensity, int maxRenderIndex, LineStyle lineStyle, bool useParallel)
         {
             if (ys == null)
                 throw new Exception("Y data cannot be null");
@@ -48,6 +48,7 @@ namespace ScottPlot
                 throw new ArgumentException("maxRenderIndex must be a valid index for ys[]");
             this.maxRenderIndex = maxRenderIndex;
             this.lineStyle = lineStyle;
+            this.useParallel = useParallel;
             brush = new SolidBrush(color);
             penLD = GDI.Pen(color, (float)lineWidth, lineStyle, true);
             penHD = GDI.Pen(color, (float)lineWidth, LineStyle.Solid, true);

--- a/src/ScottPlot/plottables/PlottableSignalXY.cs
+++ b/src/ScottPlot/plottables/PlottableSignalXY.cs
@@ -10,8 +10,8 @@ namespace ScottPlot
     public class PlottableSignalXY : PlottableSignal
     {
         public double[] xs;
-        public PlottableSignalXY(double[] xs, double[] ys, Color color, double lineWidth, double markerSize, string label, int maxRenderIndex, LineStyle lineStyle)
-            : base(ys, 1, 0, 0, color, lineWidth, markerSize, label, null, maxRenderIndex, lineStyle)
+        public PlottableSignalXY(double[] xs, double[] ys, Color color, double lineWidth, double markerSize, string label, int maxRenderIndex, LineStyle lineStyle, bool useParallel)
+            : base(ys, 1, 0, 0, color, lineWidth, markerSize, label, null, maxRenderIndex, lineStyle, useParallel)
         {
             if ((xs == null) || (ys == null))
                 throw new ArgumentException("X and Y data cannot be null");


### PR DESCRIPTION
**Purpose:**
Fix not used `maxRenderIndex` in `RenderHighDensity()` mode. #448
Additionaly refactored `RenderHighDensity()`.
For now it easy to switch between parallel and sequental implementation without code duplicates.
`useParallel` return back as `Signal` public field. No idea how better implement it in API, but let it stay configurable (imho). Parallel calculations not always better... #419

**New functionality (code):**
User can switch to sequental calculations by
```cs
var signal = plt.PlotSignal(....);
signal.useParallel = false;
```

**New functionality (image):**
Growing data demo correct render:
![image](https://user-images.githubusercontent.com/53831487/84165599-932ba880-aa7c-11ea-8184-a2b43c15d09f.png)
