### PR TITLE
fixed issues w/ barplots and negative values

### DIFF
--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -12,6 +12,7 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Linq;
+using ScottPlot.Config;
 using ScottPlot.Statistics;
 
 namespace ScottPlot
@@ -1089,13 +1090,29 @@ namespace ScottPlot
 
             settings.plottables.Add(barPlot);
 
-            if (autoAxis && !ys.Where(y => y < 0).Any())
+            if (autoAxis)
             {
+                // perform a tight axis adjustment
+                AxisAuto(0, 0);
+                double[] tightAxisLimits = Axis();
+
+                // now loosen it up a bit
                 AxisAuto();
+
                 if (horizontal)
-                    Axis(x1: 0);
+                {
+                    if (tightAxisLimits[0] == 0)
+                        Axis(x1: 0);
+                    else if (tightAxisLimits[1] == 0)
+                        Axis(x2: 0);
+                }
                 else
-                    Axis(y1: 0);
+                {
+                    if (tightAxisLimits[2] == 0)
+                        Axis(y1: 0);
+                    else if (tightAxisLimits[3] == 0)
+                        Axis(y2: 0);
+                }
             }
 
             return barPlot;

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1089,7 +1089,7 @@ namespace ScottPlot
 
             settings.plottables.Add(barPlot);
 
-            if (autoAxis)
+            if (autoAxis && !ys.Where(y => y < 0).Any())
             {
                 AxisAuto();
                 if (horizontal)
@@ -1132,14 +1132,21 @@ namespace ScottPlot
             int seriesCount = ys.Length;
             double barWidth = groupWidthFraction / seriesCount;
             PlottableBar[] bars = new PlottableBar[seriesCount];
+            bool containsNegativeY = false;
             for (int i = 0; i < seriesCount; i++)
             {
                 double offset = i * barWidth;
                 double[] barYs = ys[i];
                 double[] barYerr = yErr?[i];
                 double[] barXs = DataGen.Consecutive(barYs.Length);
+                containsNegativeY = containsNegativeY ? containsNegativeY : barYs.Where(y => y < 0).Any();
                 bars[i] = PlotBar(barXs, barYs, barYerr, seriesLabels[i], barWidth * barWidthFraction, offset,
                     errorCapSize: errorCapSize, showValues: showValues);
+            }
+
+            if (containsNegativeY)
+            {
+                AxisAuto();
             }
             XTicks(DataGen.Consecutive(groupLabels.Length, offset: (groupWidthFraction - barWidth) / 2), groupLabels);
 

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1156,7 +1156,7 @@ namespace ScottPlot
                 double[] barYs = ys[i];
                 double[] barYerr = yErr?[i];
                 double[] barXs = DataGen.Consecutive(barYs.Length);
-                containsNegativeY = containsNegativeY ? containsNegativeY : barYs.Where(y => y < 0).Any();
+                containsNegativeY |= barYs.Where(y => y < 0).Any();
                 bars[i] = PlotBar(barXs, barYs, barYerr, seriesLabels[i], barWidth * barWidthFraction, offset,
                     errorCapSize: errorCapSize, showValues: showValues);
             }

--- a/src/ScottPlot/plottables/PlottableBar.cs
+++ b/src/ScottPlot/plottables/PlottableBar.cs
@@ -145,8 +145,8 @@ namespace ScottPlot
 
             if (errorPen.Width > 0 && valueError > 0)
             {
-                double error1 = value2 - Math.Abs(valueError);
-                double error2 = value2 + Math.Abs(valueError);
+                double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+                double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
 
                 float capPx1 = (float)settings.GetPixelX(position - errorCapSize * barWidth / 2);
                 float capPx2 = (float)settings.GetPixelX(position + errorCapSize * barWidth / 2);

--- a/src/ScottPlot/plottables/PlottableBar.cs
+++ b/src/ScottPlot/plottables/PlottableBar.cs
@@ -171,7 +171,7 @@ namespace ScottPlot
             double valueSpan = value2 - value1;
 
             var rect = new RectangleF(
-                x: (float)settings.GetPixelX(valueBase),
+                x: (float)settings.GetPixelX(value1),
                 y: (float)settings.GetPixelY(edge2),
                 height: (float)(barWidth * settings.yAxisScale),
                 width: (float)(valueSpan * settings.xAxisScale));
@@ -183,8 +183,8 @@ namespace ScottPlot
 
             if (errorPen.Width > 0 && valueError > 0)
             {
-                double error1 = value2 - Math.Abs(valueError);
-                double error2 = value2 + Math.Abs(valueError);
+                double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+                double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
 
                 float capPx1 = (float)settings.GetPixelY(position - errorCapSize * barWidth / 2);
                 float capPx2 = (float)settings.GetPixelY(position + errorCapSize * barWidth / 2);

--- a/tests/PlotTypes/Bar.cs
+++ b/tests/PlotTypes/Bar.cs
@@ -20,6 +20,60 @@ namespace ScottPlotTests.PlotTypes
         }
 
         [Test]
+        public void Test_Bar_PositiveAndNegative()
+        {
+            var plt = new ScottPlot.Plot(600, 400);
+
+            string[] labels = { "one", "two", "three", "four", "five" };
+            int barCount = labels.Length;
+            Random rand = new Random(0);
+            double[] xs = ScottPlot.DataGen.Consecutive(barCount);
+            double[] ys = ScottPlot.DataGen.RandomNormal(rand, barCount, 0, 10);
+            double[] yError = ScottPlot.DataGen.RandomNormal(rand, barCount, 5, 2);
+
+            plt.PlotBar(xs, ys, yError);
+
+            plt.XTicks(xs, labels);
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Bar_PositiveOnly()
+        {
+            var plt = new ScottPlot.Plot(600, 400);
+
+            string[] labels = { "one", "two", "three", "four", "five" };
+            int barCount = labels.Length;
+            Random rand = new Random(0);
+            double[] xs = ScottPlot.DataGen.Consecutive(barCount);
+            double[] ys = ScottPlot.DataGen.RandomNormal(rand, barCount, 50, 10);
+            double[] yError = ScottPlot.DataGen.RandomNormal(rand, barCount, 5, 2);
+
+            plt.PlotBar(xs, ys, yError);
+
+            plt.XTicks(xs, labels);
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Bar_NegativeOnly()
+        {
+            var plt = new ScottPlot.Plot(600, 400);
+
+            string[] labels = { "one", "two", "three", "four", "five" };
+            int barCount = labels.Length;
+            Random rand = new Random(0);
+            double[] xs = ScottPlot.DataGen.Consecutive(barCount);
+            double[] ys = ScottPlot.DataGen.RandomNormal(rand, barCount, -50, 10);
+            double[] yError = ScottPlot.DataGen.RandomNormal(rand, barCount, 5, 2);
+
+            plt.PlotBar(xs, ys, yError);
+
+            plt.XTicks(xs, labels);
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
         public void Test_Bar_SeriesWithError()
         {
             double[] xs = { 1, 2, 3, 4, 5, 6, 7 };


### PR DESCRIPTION
New contributors should review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#461

**New functionality (code):**
N/A

**New functionality (image):**
Now bar plots with negative values look as they should:
![image](https://user-images.githubusercontent.com/8635304/84610128-d324ce00-ae76-11ea-8894-db76895c4ba0.png)


**Autoformat your code:**
The build will fail if your code is not auto-formatted. Auto-format your code in Visual Studio, or from the console using these commands:
```
cd ScottPlot/src/
dotnet tool install --global dotnet-format
dotnet format
```
