### PR TITLE
Radices

### DIFF
--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -161,17 +161,40 @@ namespace ScottPlot.Demo.Customize
             public void Render(Plot plt)
             {
                 Random rand = new Random(0);
-                int pointCount = 15;
-                double[] x = DataGen.Consecutive(pointCount);
-                double[] y = DataGen.Consecutive(pointCount);
 
-                plt.PlotScatter(x, y);
+                // create some sample data
+                double[] xs = { 0 };
+                double[] valuesA = { 0x40000000 };
+                double[] valuesB = { 0x40100000 };
+                double[] valuesC = { 0xA0000000 };
+
+
+                // to simulate stacking B on A, shift B up by A
+                double[] valuesB2 = new double[valuesB.Length];
+                double[] valuesC2 = new double[valuesC.Length];
+                for (int i = 0; i < valuesB.Length; i++)
+                {
+                    valuesB2[i] = valuesA[i] + valuesB[i];
+                    valuesC2[i] = valuesC[i] + valuesB2[i];
+                }
+
+                // plot the bar charts in reverse order (highest first)
+                plt.PlotBar(xs, valuesC2, label: "Process C");
+                plt.PlotBar(xs, valuesB2, label: "Process B");
+                plt.PlotBar(xs, valuesA, label: "Process A");
 
                 //Base 10 on x axis, base 16 on y axis
                 int[] radices = { 10, 16 };
                 string[] prefices = { "", "0x" };
 
                 plt.Ticks(radices: radices, prefices: prefices);
+                plt.Title("Memory Consumption");
+                plt.YLabel("Memory (Bytes)");
+
+                plt.Ticks(false, true);
+                plt.Axis(-1, 1, 0, 0x1A0000000);
+
+                plt.Legend();
             }
         }
     }

--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -152,5 +152,27 @@ namespace ScottPlot.Demo.Customize
                 plt.Title("DateTime Axis Labels");
             }
         }
+
+        public class HexadecimalAxis : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Hexadecimal Axis";
+            public string description { get; } = "Axis tick labels can be in any base, not just base 10";
+
+            public void Render(Plot plt)
+            {
+                Random rand = new Random(0);
+                int pointCount = 5;
+                double[] x = DataGen.Consecutive(pointCount);
+                double[] y = DataGen.NoisyLinear(rand, pointCount);
+
+                plt.PlotScatter(x, y);
+
+                //Base 10 on x axis, base 16 on y axis
+                int[] radices = { 16, 16 };
+                string[] prefices = { "0x", "0x" };
+
+                plt.Ticks(radices: radices, prefices: prefices);
+            }
+        }
     }
 }

--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -168,8 +168,8 @@ namespace ScottPlot.Demo.Customize
                 plt.PlotScatter(x, y);
 
                 //Base 10 on x axis, base 16 on y axis
-                int[] radices = { 16, 16 };
-                string[] prefices = { "0x", "0x" };
+                int[] radices = { 10, 16 };
+                string[] prefices = { "", "0x" };
 
                 plt.Ticks(radices: radices, prefices: prefices);
             }

--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -161,9 +161,9 @@ namespace ScottPlot.Demo.Customize
             public void Render(Plot plt)
             {
                 Random rand = new Random(0);
-                int pointCount = 5;
+                int pointCount = 15;
                 double[] x = DataGen.Consecutive(pointCount);
-                double[] y = DataGen.NoisyLinear(rand, pointCount);
+                double[] y = DataGen.Consecutive(pointCount);
 
                 plt.PlotScatter(x, y);
 

--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -160,14 +160,11 @@ namespace ScottPlot.Demo.Customize
 
             public void Render(Plot plt)
             {
-                Random rand = new Random(0);
-
                 // create some sample data
                 double[] xs = { 0 };
                 double[] valuesA = { 0x40000000 };
                 double[] valuesB = { 0x40100000 };
                 double[] valuesC = { 0xA0000000 };
-
 
                 // to simulate stacking B on A, shift B up by A
                 double[] valuesB2 = new double[valuesB.Length];
@@ -183,17 +180,14 @@ namespace ScottPlot.Demo.Customize
                 plt.PlotBar(xs, valuesB2, label: "Process B");
                 plt.PlotBar(xs, valuesA, label: "Process A");
 
-                //Base 10 on x axis, base 16 on y axis
-                int[] radices = { 10, 16 };
-                string[] prefices = { "", "0x" };
-
-                plt.Ticks(radices: radices, prefices: prefices);
-                plt.Title("Memory Consumption");
-                plt.YLabel("Memory (Bytes)");
-
-                plt.Ticks(false, true);
+                // configure ticks for base 16 Y-axis
+                plt.Ticks(baseY: 16, prefixY: "0x");
                 plt.Axis(-1, 1, 0, 0x1A0000000);
 
+                // further customize the plot
+                plt.Ticks(displayTicksX: false, displayTicksY: true);
+                plt.Title("Memory Consumption");
+                plt.YLabel("Memory (Bytes)");
                 plt.Legend();
             }
         }

--- a/src/ScottPlot/Config/TickCollection.cs
+++ b/src/ScottPlot/Config/TickCollection.cs
@@ -30,6 +30,10 @@ namespace ScottPlot.Config
         public bool logScale;
         public string numericFormatString;
 
+        public int radix = 10;
+        public string prefix = null;
+
+
         public TickCollection(bool verticalAxis)
         {
             this.verticalAxis = verticalAxis;

--- a/src/ScottPlot/Config/Ticks.cs
+++ b/src/ScottPlot/Config/Ticks.cs
@@ -42,5 +42,8 @@ namespace ScottPlot.Config
         public bool useExponentialNotation = true;
 
         public bool snapToNearestPixel = true;
+
+        public double radix = 10;
+        public string prefix = null;
     }
 }

--- a/src/ScottPlot/Config/Ticks.cs
+++ b/src/ScottPlot/Config/Ticks.cs
@@ -42,6 +42,5 @@ namespace ScottPlot.Config
         public bool useExponentialNotation = true;
 
         public bool snapToNearestPixel = true;
-
     }
 }

--- a/src/ScottPlot/Config/Ticks.cs
+++ b/src/ScottPlot/Config/Ticks.cs
@@ -43,7 +43,5 @@ namespace ScottPlot.Config
 
         public bool snapToNearestPixel = true;
 
-        public double radix = 10;
-        public string prefix = null;
     }
 }

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1844,8 +1844,10 @@ namespace ScottPlot
             string numericFormatStringX = null,
             string numericFormatStringY = null,
             bool? snapToNearestPixel = null,
-            int[] radices = null,
-            string[] prefices = null
+            int? baseX = null,
+            int? baseY = null,
+            string prefixX = null,
+            string prefixY = null
             )
         {
             if (displayTicksX != null)
@@ -1896,15 +1898,15 @@ namespace ScottPlot
                 settings.ticks.y.numericFormatString = numericFormatStringY;
             if (snapToNearestPixel != null)
                 settings.ticks.snapToNearestPixel = snapToNearestPixel.Value;
-            if (radices != null)
+            if (baseX != null)
             {
-                settings.ticks.x.radix = radices[0];
-                settings.ticks.y.radix = radices[1];
+                settings.ticks.x.radix = baseX.Value;
+                settings.ticks.x.prefix = prefixX;
             }
-            if (prefices != null)
+            if (baseY != null)
             {
-                settings.ticks.x.prefix = prefices[0];
-                settings.ticks.y.prefix = prefices[1];
+                settings.ticks.y.radix = baseY.Value;
+                settings.ticks.y.prefix = prefixY;
             }
 
             // dont use offset notation if the sign is inverted

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1843,7 +1843,9 @@ namespace ScottPlot
             bool? logScaleY = null,
             string numericFormatStringX = null,
             string numericFormatStringY = null,
-            bool? snapToNearestPixel = null
+            bool? snapToNearestPixel = null,
+            double? radix = 10,
+            string prefix = null
             )
         {
             if (displayTicksX != null)
@@ -1894,6 +1896,10 @@ namespace ScottPlot
                 settings.ticks.y.numericFormatString = numericFormatStringY;
             if (snapToNearestPixel != null)
                 settings.ticks.snapToNearestPixel = snapToNearestPixel.Value;
+            if (radix != null)
+                settings.ticks.radix = radix.Value;
+            if (prefix != null)
+                settings.ticks.prefix = prefix;
 
             // dont use offset notation if the sign is inverted
             if (settings.ticks.x.invertSign || settings.ticks.y.invertSign)

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1844,8 +1844,8 @@ namespace ScottPlot
             string numericFormatStringX = null,
             string numericFormatStringY = null,
             bool? snapToNearestPixel = null,
-            double? radix = 10,
-            string prefix = null
+            int[] radices = null,
+            string[] prefices = null
             )
         {
             if (displayTicksX != null)
@@ -1896,10 +1896,16 @@ namespace ScottPlot
                 settings.ticks.y.numericFormatString = numericFormatStringY;
             if (snapToNearestPixel != null)
                 settings.ticks.snapToNearestPixel = snapToNearestPixel.Value;
-            if (radix != null)
-                settings.ticks.radix = radix.Value;
-            if (prefix != null)
-                settings.ticks.prefix = prefix;
+            if (radices != null)
+            {
+                settings.ticks.x.radix = radices[0];
+                settings.ticks.y.radix = radices[1];
+            }
+            if (prefices != null)
+            {
+                settings.ticks.x.prefix = prefices[0];
+                settings.ticks.y.prefix = prefices[1];
+            }
 
             // dont use offset notation if the sign is inverted
             if (settings.ticks.x.invertSign || settings.ticks.y.invertSign)

--- a/src/ScottPlot/Renderer.cs
+++ b/src/ScottPlot/Renderer.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using ScottPlot.Config;
 using ScottPlot.Drawing;
 
 namespace ScottPlot
@@ -237,7 +238,15 @@ namespace ScottPlot
             for (int i = 0; i < settings.ticks.y.tickPositionsMajor.Length; i++)
             {
                 double value = settings.ticks.y.tickPositionsMajor[i];
-                string text = settings.ticks.y.tickLabels[i];
+                string text;
+                if (settings.ticks.y.radix == 10)
+                {
+                    text = settings.ticks.y.tickLabels[i];
+                }
+                else
+                {
+                    text = (settings.ticks.y.prefix ?? "") + Tools.ToDifferentBase(value, settings.ticks.y.radix);
+                }
 
                 double unitsFromAxisEdge = value - settings.axes.y.min;
                 double xPx = settings.dataOrigin.X - 1;
@@ -289,7 +298,15 @@ namespace ScottPlot
             for (int i = 0; i < settings.ticks.x.tickPositionsMajor.Length; i++)
             {
                 double value = settings.ticks.x.tickPositionsMajor[i];
-                string text = settings.ticks.x.tickLabels[i];
+                string text;
+                if (settings.ticks.x.radix == 10)
+                {
+                    text = settings.ticks.x.tickLabels[i];
+                }
+                else
+                {
+                    text = (settings.ticks.x.prefix ?? "") + Tools.ToDifferentBase(value, settings.ticks.x.radix);
+                }
 
                 double unitsFromAxisEdge = value - settings.axes.x.min;
                 double xPx = unitsFromAxisEdge * settings.xAxisScale + settings.layout.data.left;

--- a/src/ScottPlot/Renderer.cs
+++ b/src/ScottPlot/Renderer.cs
@@ -238,15 +238,9 @@ namespace ScottPlot
             for (int i = 0; i < settings.ticks.y.tickPositionsMajor.Length; i++)
             {
                 double value = settings.ticks.y.tickPositionsMajor[i];
-                string text;
-                if (settings.ticks.y.radix == 10)
-                {
-                    text = settings.ticks.y.tickLabels[i];
-                }
-                else
-                {
-                    text = (settings.ticks.y.prefix ?? "") + Tools.ToDifferentBase(value, settings.ticks.y.radix);
-                }
+                string text = (settings.ticks.y.radix == 10) ?
+                    settings.ticks.y.tickLabels[i] :
+                    settings.ticks.y.prefix + Tools.ToDifferentBase(value, settings.ticks.y.radix);
 
                 double unitsFromAxisEdge = value - settings.axes.y.min;
                 double xPx = settings.dataOrigin.X - 1;
@@ -298,15 +292,9 @@ namespace ScottPlot
             for (int i = 0; i < settings.ticks.x.tickPositionsMajor.Length; i++)
             {
                 double value = settings.ticks.x.tickPositionsMajor[i];
-                string text;
-                if (settings.ticks.x.radix == 10)
-                {
-                    text = settings.ticks.x.tickLabels[i];
-                }
-                else
-                {
-                    text = (settings.ticks.x.prefix ?? "") + Tools.ToDifferentBase(value, settings.ticks.x.radix);
-                }
+                string text = (settings.ticks.x.radix == 10) ?
+                    settings.ticks.x.tickLabels[i] :
+                    settings.ticks.x.prefix + Tools.ToDifferentBase(value, settings.ticks.x.radix);
 
                 double unitsFromAxisEdge = value - settings.axes.x.min;
                 double xPx = unitsFromAxisEdge * settings.xAxisScale + settings.layout.data.left;

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -406,7 +406,7 @@ namespace ScottPlot
             return output;
         }
 
-        public static string ToDifferentBase(double number, int radix = 16, int decimalPlaces = 3, int padInteger = 0)
+        public static string ToDifferentBase(double number, int radix = 16, int decimalPlaces = 3, int padInteger = 0, bool dropTrailingZeroes = true)
         {
             char[] symbols = "0123456789ABCDEF".ToCharArray();
             double epsilon = Math.Pow(radix, -decimalPlaces);
@@ -436,6 +436,18 @@ namespace ScottPlot
             {
                 output += ".";
                 output += ToDifferentBase(Math.Round(decimalPart * Math.Pow(radix, decimalPlaces)), radix, decimalPlaces, decimalPlaces);
+                if (dropTrailingZeroes)
+                {
+                    while (output.Last() == '0')
+                    {
+                        output = output.Substring(0, output.Length - 1);
+                    }
+
+                    if (output.Last() == '.')
+                    {
+                        output = output.Substring(0, output.Length - 1);
+                    }
+                }
             }
 
             return output;

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -406,7 +406,7 @@ namespace ScottPlot
             return output;
         }
 
-        public static string ToDifferentBase(double number, double radix = 16, int decimalPlaces = 3, int padInteger = 0)
+        public static string ToDifferentBase(double number, int radix = 16, int decimalPlaces = 3, int padInteger = 0)
         {
             char[] symbols = "0123456789ABCDEF".ToCharArray();
             double epsilon = Math.Pow(radix, -decimalPlaces);
@@ -427,12 +427,12 @@ namespace ScottPlot
                 number /= radix;
             }
 
-            while(output.Length < padInteger)
+            while (output.Length < padInteger)
             {
                 output = "0" + output;
             }
 
-            if(decimalLength != 0)
+            if (decimalLength != 0)
             {
                 output += ".";
                 output += ToDifferentBase(Math.Round(decimalPart * Math.Pow(radix, decimalPlaces)), radix, decimalPlaces, decimalPlaces);

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -405,5 +405,40 @@ namespace ScottPlot
 
             return output;
         }
+
+        public static string ToDifferentBase(double number, double radix = 16, int decimalPlaces = 3, int padInteger = 0)
+        {
+            char[] symbols = "0123456789ABCDEF".ToCharArray();
+            double epsilon = Math.Pow(radix, -decimalPlaces);
+
+            if (radix > symbols.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(radix));
+            }
+
+            int integerLength = (int)Math.Ceiling(Math.Log(number, radix));
+            int decimalLength = number % 1 > epsilon ? decimalPlaces : 0;
+            double decimalPart = number % 1;
+            string output = "";
+
+            for (int i = 0; i < integerLength; i++)
+            {
+                output = symbols[(int)(number % radix)] + output;
+                number /= radix;
+            }
+
+            while(output.Length < padInteger)
+            {
+                output = "0" + output;
+            }
+
+            if(decimalLength != 0)
+            {
+                output += ".";
+                output += ToDifferentBase(Math.Round(decimalPart * Math.Pow(radix, decimalPlaces)), radix, decimalPlaces, decimalPlaces);
+            }
+
+            return output;
+        }
     }
 }

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -408,7 +408,21 @@ namespace ScottPlot
 
         public static string ToDifferentBase(double number, int radix = 16, int decimalPlaces = 3, int padInteger = 0, bool dropTrailingZeroes = true)
         {
+            if (number < 0)
+            {
+                return "-" + ToDifferentBase(Math.Abs(number), radix, decimalPlaces, padInteger, dropTrailingZeroes);
+            }
+            else if (number == 0)
+            {
+                return "0";
+            }
+
             char[] symbols = "0123456789ABCDEF".ToCharArray();
+            if (radix > symbols.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(radix));
+            }
+
             double epsilon = Math.Pow(radix, -decimalPlaces);
 
             if (radix > symbols.Length)

--- a/tests/Tools/ChangingBase.cs
+++ b/tests/Tools/ChangingBase.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ScottPlotTests.Tools
+{
+	class ChangingBase
+	{
+		[TestCase(255, 16, "FF")]
+		[TestCase(112, 16, "70")]
+		[TestCase(127, 16, "7F")]
+		[TestCase(255, 2, "11111111")]
+		[TestCase(15, 2, "1111")]
+		public void TestIntegers(double number, double radix, string expectedOutput)
+		{
+			Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix));
+		}
+
+		[TestCase(200.1, 16, 3, "C8.19A")]
+		[TestCase(200.1, 16, 9, "C8.19999999A")]
+		[TestCase(200.1, 2, 5, "11001000.00011")]
+		[TestCase(200.1, 2, 3, "11001000")]
+		[TestCase(255.3, 16, 3, "FF.4CD")]
+		[TestCase(255.3, 16, 9, "FF.4CCCCCCCD")]
+		[TestCase(255.3, 2, 3, "11111111.000")]
+		[TestCase(255.3, 2, 9, "11111111.010011010")]
+		[TestCase(255.3, 16, 1, "FF.5")]
+		[TestCase(255.3, 2, 1, "11111111")]
+		public void TestDecimals(double number, double radix, int decimalPlaces, string expectedOutput)
+		{
+			Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces));
+		}
+	}
+}

--- a/tests/Tools/ChangingBase.cs
+++ b/tests/Tools/ChangingBase.cs
@@ -5,31 +5,31 @@ using System.Text;
 
 namespace ScottPlotTests.Tools
 {
-	class ChangingBase
-	{
-		[TestCase(255, 16, "FF")]
-		[TestCase(112, 16, "70")]
-		[TestCase(127, 16, "7F")]
-		[TestCase(255, 2, "11111111")]
-		[TestCase(15, 2, "1111")]
-		public void TestIntegers(double number, double radix, string expectedOutput)
-		{
-			Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix));
-		}
+    class ChangingBase
+    {
+        [TestCase(255, 16, "FF")]
+        [TestCase(112, 16, "70")]
+        [TestCase(127, 16, "7F")]
+        [TestCase(255, 2, "11111111")]
+        [TestCase(15, 2, "1111")]
+        public void TestIntegers(double number, int radix, string expectedOutput)
+        {
+            Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix));
+        }
 
-		[TestCase(200.1, 16, 3, "C8.19A")]
-		[TestCase(200.1, 16, 9, "C8.19999999A")]
-		[TestCase(200.1, 2, 5, "11001000.00011")]
-		[TestCase(200.1, 2, 3, "11001000")]
-		[TestCase(255.3, 16, 3, "FF.4CD")]
-		[TestCase(255.3, 16, 9, "FF.4CCCCCCCD")]
-		[TestCase(255.3, 2, 3, "11111111.000")]
-		[TestCase(255.3, 2, 9, "11111111.010011010")]
-		[TestCase(255.3, 16, 1, "FF.5")]
-		[TestCase(255.3, 2, 1, "11111111")]
-		public void TestDecimals(double number, double radix, int decimalPlaces, string expectedOutput)
-		{
-			Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces));
-		}
-	}
+        [TestCase(200.1, 16, 3, "C8.19A")]
+        [TestCase(200.1, 16, 9, "C8.19999999A")]
+        [TestCase(200.1, 2, 5, "11001000.00011")]
+        [TestCase(200.1, 2, 3, "11001000")]
+        [TestCase(255.3, 16, 3, "FF.4CD")]
+        [TestCase(255.3, 16, 9, "FF.4CCCCCCCD")]
+        [TestCase(255.3, 2, 3, "11111111.000")]
+        [TestCase(255.3, 2, 9, "11111111.010011010")]
+        [TestCase(255.3, 16, 1, "FF.5")]
+        [TestCase(255.3, 2, 1, "11111111")]
+        public void TestDecimals(double number, int radix, int decimalPlaces, string expectedOutput)
+        {
+            Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces));
+        }
+    }
 }

--- a/tests/Tools/ChangingBase.cs
+++ b/tests/Tools/ChangingBase.cs
@@ -17,19 +17,21 @@ namespace ScottPlotTests.Tools
             Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix));
         }
 
-        [TestCase(200.1, 16, 3, "C8.19A")]
-        [TestCase(200.1, 16, 9, "C8.19999999A")]
-        [TestCase(200.1, 2, 5, "11001000.00011")]
-        [TestCase(200.1, 2, 3, "11001000")]
-        [TestCase(255.3, 16, 3, "FF.4CD")]
-        [TestCase(255.3, 16, 9, "FF.4CCCCCCCD")]
-        [TestCase(255.3, 2, 3, "11111111.000")]
-        [TestCase(255.3, 2, 9, "11111111.010011010")]
-        [TestCase(255.3, 16, 1, "FF.5")]
-        [TestCase(255.3, 2, 1, "11111111")]
-        public void TestDecimals(double number, int radix, int decimalPlaces, string expectedOutput)
+        [TestCase(200.1, 16, 3, true, "C8.19A")]
+        [TestCase(200.1, 16, 9, true, "C8.19999999A")]
+        [TestCase(200.1, 2, 5, true, "11001000.00011")]
+        [TestCase(200.1, 2, 3, true, "11001000")]
+        [TestCase(255.3, 16, 3, true, "FF.4CD")]
+        [TestCase(255.3, 16, 9, true, "FF.4CCCCCCCD")]
+        [TestCase(255.3, 2, 3, true, "11111111")]
+        [TestCase(255.3, 2, 9, true, "11111111.01001101")]
+        [TestCase(255.3, 2, 3, false, "11111111.000")]
+        [TestCase(255.3, 2, 9, false, "11111111.010011010")]
+        [TestCase(255.3, 16, 1, true, "FF.5")]
+        [TestCase(255.3, 2, 1, true, "11111111")]
+        public void TestDecimals(double number, int radix, int decimalPlaces, bool dropTrailingZeroes, string expectedOutput)
         {
-            Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces));
+            Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces, dropTrailingZeroes: dropTrailingZeroes));
         }
     }
 }

--- a/tests/Tools/ChangingBase.cs
+++ b/tests/Tools/ChangingBase.cs
@@ -12,6 +12,15 @@ namespace ScottPlotTests.Tools
         [TestCase(127, 16, "7F")]
         [TestCase(255, 2, "11111111")]
         [TestCase(15, 2, "1111")]
+        [TestCase(0, 2, "0")]
+        [TestCase(-0, 2, "0")]
+
+        [TestCase(-255, 16, "-FF")]
+        [TestCase(-112, 16, "-70")]
+        [TestCase(-127, 16, "-7F")]
+        [TestCase(-255, 2, "-11111111")]
+        [TestCase(-15, 2, "-1111")]
+
         public void TestIntegers(double number, int radix, string expectedOutput)
         {
             Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix));
@@ -29,9 +38,28 @@ namespace ScottPlotTests.Tools
         [TestCase(255.3, 2, 9, false, "11111111.010011010")]
         [TestCase(255.3, 16, 1, true, "FF.5")]
         [TestCase(255.3, 2, 1, true, "11111111")]
+
+        [TestCase(-200.1, 16, 3, true, "-C8.19A")]
+        [TestCase(-200.1, 16, 9, true, "-C8.19999999A")]
+        [TestCase(-200.1, 2, 5, true, "-11001000.00011")]
+        [TestCase(-200.1, 2, 3, true, "-11001000")]
+        [TestCase(-255.3, 16, 3, true, "-FF.4CD")]
+        [TestCase(-255.3, 16, 9, true, "-FF.4CCCCCCCD")]
+        [TestCase(-255.3, 2, 3, true, "-11111111")]
+        [TestCase(-255.3, 2, 9, true, "-11111111.01001101")]
+        [TestCase(-255.3, 2, 3, false, "-11111111.000")]
+        [TestCase(-255.3, 2, 9, false, "-11111111.010011010")]
+        [TestCase(-255.3, 16, 1, true, "-FF.5")]
+        [TestCase(-255.3, 2, 1, true, "-11111111")]
         public void TestDecimals(double number, int radix, int decimalPlaces, bool dropTrailingZeroes, string expectedOutput)
         {
             Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces, dropTrailingZeroes: dropTrailingZeroes));
+        }
+
+        [Test]
+        public void TestOutOfRange()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => ScottPlot.Tools.ToDifferentBase(10, 17));//If we add extra symbols (i.e. base64) this will no longer throw
         }
     }
 }


### PR DESCRIPTION
New contributors should review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#469 

**New functionality (code):**
Provide a code example demonstrating new functionality achieved with this pull request (if applicable):

```cs
//Base 10 on x axis, base 16 on y axis
int[] radices = { 10, 16 };
string[] prefices = { "", "0x" };

plt.Ticks(radices: radices, prefices: prefices);
```

It also adds the `ScottPlot.Tools.ToDifferentBase` method:

```cs
 public static string ToDifferentBase(double number, int radix = 16, int decimalPlaces = 3, int padInteger = 0, bool dropTrailingZeroes = true)
```

There are some tests for this method in `ScottPlotTests.Tools.ChangingBase`

**New functionality (image):**
![image](https://user-images.githubusercontent.com/8635304/85475630-a27a1e00-b573-11ea-8180-8cc62e3c0ad3.png)


**Autoformat your code:**
The build will fail if your code is not auto-formatted. Auto-format your code in Visual Studio, or from the console using these commands:
```
cd ScottPlot/src/
dotnet tool install --global dotnet-format
dotnet format
```
