### PR TITLE
bar plot support for Y offset

### DIFF
--- a/src/ScottPlot.Demo/PlotTypes/Bar.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Bar.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace ScottPlot.Demo.PlotTypes
@@ -138,6 +139,24 @@ namespace ScottPlot.Demo.PlotTypes
                 // customize the plot to make it look nicer
                 plt.Grid(enableVertical: false, lineStyle: LineStyle.Dot);
                 plt.Legend();
+            }
+        }
+
+        public class Waterfall : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Waterfall Plot";
+            public string description { get; } = "You can use the yOffsets parameter to create a waterfall plot";
+
+            public void Render(Plot plt)
+            {
+                // generate random data to plot
+                Random rand = new Random(0);
+                int pointCount = 10;
+                double[] xs = DataGen.Consecutive(pointCount);
+                double[] ys = DataGen.RandomNormal(rand, pointCount, 5, 10);
+                double[] yOffsets = Enumerable.Range(0, pointCount).Select(count => ys.Take(count).Sum()).ToArray();
+
+                plt.PlotBar(xs, ys, yOffsets: yOffsets);
             }
         }
 

--- a/src/ScottPlot.Demo/PlotTypes/Bar.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Bar.cs
@@ -151,12 +151,19 @@ namespace ScottPlot.Demo.PlotTypes
             {
                 // generate random data to plot
                 Random rand = new Random(0);
-                int pointCount = 10;
+                int pointCount = 12;
                 double[] xs = DataGen.Consecutive(pointCount);
                 double[] ys = DataGen.RandomNormal(rand, pointCount, 5, 10);
-                double[] yOffsets = Enumerable.Range(0, pointCount).Select(count => ys.Take(count).Sum()).ToArray();
 
-                plt.PlotBar(xs, ys, yOffsets: yOffsets);
+                System.Drawing.Color profitColor = System.Drawing.Color.Green;
+                System.Drawing.Color lossColor = System.Drawing.Color.Red;
+                string[] monthNames = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+
+                plt.PlotWaterfall(xs, ys, fillColor: profitColor, negativeColor: lossColor);
+                plt.Title("Y1 Profits");
+                plt.XLabel("Month");
+                plt.XTicks(monthNames);
+                plt.YLabel("Million USD");
             }
         }
 

--- a/src/ScottPlot.Demo/PlotTypes/Bar.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Bar.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 
@@ -145,25 +146,23 @@ namespace ScottPlot.Demo.PlotTypes
         public class Waterfall : PlotDemo, IPlotDemo
         {
             public string name { get; } = "Waterfall Plot";
-            public string description { get; } = "You can use the yOffsets parameter to create a waterfall plot";
+            public string description { get; } = "Waterfall plots are a type of box plot where each box starts where the previous box ended.";
 
             public void Render(Plot plt)
             {
-                // generate random data to plot
+                // generate random monthly data
                 Random rand = new Random(0);
-                int pointCount = 12;
-                double[] xs = DataGen.Consecutive(pointCount);
-                double[] ys = DataGen.RandomNormal(rand, pointCount, 5, 10);
+                double[] monthProfits = DataGen.RandomNormal(rand, 12, 5, 10);
+                double[] monthNumbers = DataGen.Consecutive(12);
+                string[] monthNames = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 
-                System.Drawing.Color profitColor = System.Drawing.Color.Green;
-                System.Drawing.Color lossColor = System.Drawing.Color.Red;
-                string[] monthNames = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+                plt.PlotWaterfall(monthNumbers, monthProfits, 
+                    fillColor: Color.Green, negativeColor: Color.Red);
 
-                plt.PlotWaterfall(xs, ys, fillColor: profitColor, negativeColor: lossColor);
-                plt.Title("Y1 Profits");
-                plt.XLabel("Month");
                 plt.XTicks(monthNames);
-                plt.YLabel("Million USD");
+                plt.YLabel("Valuation (million USD)");
+                plt.Title("Company Value in 2020");
             }
         }
 

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1059,6 +1059,49 @@ namespace ScottPlot
             return pie;
         }
 
+        public PlottableBar PlotWaterfall(
+            double[] xs,
+            double[] ys,
+            double[] errorY = null,
+            string label = null,
+            double barWidth = .8,
+            double xOffset = 0,
+            bool fill = true,
+            Color? fillColor = null,
+            double outlineWidth = 1,
+            Color? outlineColor = null,
+            double errorLineWidth = 1,
+            double errorCapSize = .38,
+            Color? errorColor = null,
+            bool horizontal = false,
+            bool showValues = false,
+            bool autoAxis = true,
+            Color? negativeColor = null
+            )
+        {
+            double[] yOffsets = Enumerable.Range(0, ys.Length).Select(count => ys.Take(count).Sum()).ToArray();
+            return PlotBar(
+                xs,
+                ys,
+                errorY,
+                label,
+                barWidth,
+                xOffset,
+                fill,
+                fillColor,
+                outlineWidth,
+                outlineColor,
+                errorLineWidth,
+                errorCapSize,
+                errorColor,
+                horizontal,
+                showValues,
+                autoAxis,
+                yOffsets,
+                negativeColor
+            );
+        }
+
         public PlottableBar PlotBar(
             double[] xs,
             double[] ys,
@@ -1076,7 +1119,8 @@ namespace ScottPlot
             bool horizontal = false,
             bool showValues = false,
             bool autoAxis = true,
-            double[] yOffsets = null
+            double[] yOffsets = null,
+            Color? negativeColor = null
             )
         {
             if (fillColor == null)
@@ -1087,6 +1131,11 @@ namespace ScottPlot
 
             if (errorColor == null)
                 errorColor = Color.Black;
+
+            if (!negativeColor.HasValue)
+            {
+                negativeColor = fillColor;
+            }
 
             PlottableBar barPlot = new PlottableBar(
                 xs: xs,
@@ -1104,7 +1153,8 @@ namespace ScottPlot
                 outlineColor: outlineColor.Value,
                 horizontal: horizontal,
                 showValues: showValues,
-                yOffsets: yOffsets
+                yOffsets: yOffsets,
+                negativeColor: negativeColor.Value
                 );
 
             settings.plottables.Add(barPlot);

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1075,7 +1075,8 @@ namespace ScottPlot
             Color? errorColor = null,
             bool horizontal = false,
             bool showValues = false,
-            bool autoAxis = true
+            bool autoAxis = true,
+            double[] yOffsets = null
             )
         {
             if (fillColor == null)
@@ -1102,7 +1103,8 @@ namespace ScottPlot
                 outlineWidth: outlineWidth,
                 outlineColor: outlineColor.Value,
                 horizontal: horizontal,
-                showValues: showValues
+                showValues: showValues,
+                yOffsets: yOffsets
                 );
 
             settings.plottables.Add(barPlot);

--- a/src/ScottPlot/plottables/PlottableBar.cs
+++ b/src/ScottPlot/plottables/PlottableBar.cs
@@ -17,6 +17,7 @@ namespace ScottPlot
 
         public LineStyle lineStyle;
         public Color fillColor;
+        public Color negativeColor;
         public double[] yOffsets;
         public string label;
 
@@ -41,7 +42,7 @@ namespace ScottPlot
             bool fill, Color fillColor,
             double outlineWidth, Color outlineColor,
             double[] yErr, double errorLineWidth, double errorCapSize, Color errorColor,
-            bool horizontal, bool showValues, double[] yOffsets
+            bool horizontal, bool showValues, double[] yOffsets, Color negativeColor
             )
         {
             if (ys is null || ys.Length == 0)
@@ -62,6 +63,7 @@ namespace ScottPlot
             if (yOffsets is null)
                 yOffsets = DataGen.Zeros(ys.Length);
 
+
             this.xs = xs;
             this.ys = ys;
             this.yErr = yErr;
@@ -75,6 +77,7 @@ namespace ScottPlot
 
             this.fill = fill;
             this.fillColor = fillColor;
+            this.negativeColor = negativeColor;
 
             this.yOffsets = yOffsets;
 
@@ -138,6 +141,15 @@ namespace ScottPlot
             double value2 = Math.Max(valueBase, value) + yOffset;
             double valueSpan = value2 - value1;
 
+            if (value < 0)
+            {
+                ((SolidBrush)fillBrush).Color = negativeColor;
+            }
+            else
+            {
+                ((SolidBrush)fillBrush).Color = fillColor;
+            }
+
             var rect = new RectangleF(
                 x: (float)settings.GetPixelX(edge1),
                 y: (float)settings.GetPixelY(value2),
@@ -175,6 +187,15 @@ namespace ScottPlot
             double value1 = Math.Min(valueBase, value) + yOffset;
             double value2 = Math.Max(valueBase, value) + yOffset;
             double valueSpan = value2 - value1;
+
+            if (value < 0)
+            {
+                ((SolidBrush)fillBrush).Color = negativeColor;
+            }
+            else
+            {
+                ((SolidBrush)fillBrush).Color = fillColor;
+            }
 
             var rect = new RectangleF(
                 x: (float)settings.GetPixelX(value1),

--- a/src/ScottPlot/plottables/PlottableBar.cs
+++ b/src/ScottPlot/plottables/PlottableBar.cs
@@ -17,6 +17,7 @@ namespace ScottPlot
 
         public LineStyle lineStyle;
         public Color fillColor;
+        public double[] yOffsets;
         public string label;
 
         private double errorCapSize;
@@ -40,7 +41,7 @@ namespace ScottPlot
             bool fill, Color fillColor,
             double outlineWidth, Color outlineColor,
             double[] yErr, double errorLineWidth, double errorCapSize, Color errorColor,
-            bool horizontal, bool showValues
+            bool horizontal, bool showValues, double[] yOffsets
             )
         {
             if (ys is null || ys.Length == 0)
@@ -58,6 +59,9 @@ namespace ScottPlot
             if (yErr.Length != ys.Length)
                 throw new ArgumentException("yErr and ys must have same number of elements");
 
+            if (yOffsets is null)
+                yOffsets = DataGen.Zeros(ys.Length);
+
             this.xs = xs;
             this.ys = ys;
             this.yErr = yErr;
@@ -71,6 +75,8 @@ namespace ScottPlot
 
             this.fill = fill;
             this.fillColor = fillColor;
+
+            this.yOffsets = yOffsets;
 
             fillBrush = new SolidBrush(fillColor);
             outlinePen = new Pen(outlineColor, (float)outlineWidth);
@@ -89,8 +95,8 @@ namespace ScottPlot
 
             for (int i = 0; i < xs.Length; i++)
             {
-                valueMin = Math.Min(valueMin, ys[i] - yErr[i]);
-                valueMax = Math.Max(valueMax, ys[i] + yErr[i]);
+                valueMin = Math.Min(valueMin, ys[i] - yErr[i] + yOffsets[i]);
+                valueMax = Math.Max(valueMax, ys[i] + yErr[i] + yOffsets[i]);
                 positionMin = Math.Min(positionMin, xs[i]);
                 positionMax = Math.Max(positionMax, xs[i]);
             }
@@ -118,18 +124,18 @@ namespace ScottPlot
             for (int i = 0; i < ys.Length; i++)
             {
                 if (verticalBars)
-                    RenderBarVertical(settings, xs[i] + xOffset, ys[i], yErr[i]);
+                    RenderBarVertical(settings, xs[i] + xOffset, ys[i], yErr[i], yOffsets[i]);
                 else
-                    RenderBarHorizontal(settings, xs[i] + xOffset, ys[i], yErr[i]);
+                    RenderBarHorizontal(settings, xs[i] + xOffset, ys[i], yErr[i], yOffsets[i]);
             }
         }
 
-        private void RenderBarVertical(Settings settings, double position, double value, double valueError)
+        private void RenderBarVertical(Settings settings, double position, double value, double valueError, double yOffset)
         {
             float centerPx = (float)settings.GetPixelX(position);
             double edge1 = position - barWidth / 2;
-            double value1 = Math.Min(valueBase, value);
-            double value2 = Math.Max(valueBase, value);
+            double value1 = Math.Min(valueBase, value) + yOffset;
+            double value2 = Math.Max(valueBase, value) + yOffset;
             double valueSpan = value2 - value1;
 
             var rect = new RectangleF(
@@ -162,12 +168,12 @@ namespace ScottPlot
                 settings.gfxData.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, settings.misc.sfSouth);
         }
 
-        private void RenderBarHorizontal(Settings settings, double position, double value, double valueError)
+        private void RenderBarHorizontal(Settings settings, double position, double value, double valueError, double yOffset)
         {
             float centerPx = (float)settings.GetPixelY(position);
             double edge2 = position + barWidth / 2;
-            double value1 = Math.Min(valueBase, value);
-            double value2 = Math.Max(valueBase, value);
+            double value1 = Math.Min(valueBase, value) + yOffset;
+            double value2 = Math.Max(valueBase, value) + yOffset;
             double valueSpan = value2 - value1;
 
             var rect = new RectangleF(

--- a/src/ScottPlot/plottables/PlottableBar.cs
+++ b/src/ScottPlot/plottables/PlottableBar.cs
@@ -141,14 +141,7 @@ namespace ScottPlot
             double value2 = Math.Max(valueBase, value) + yOffset;
             double valueSpan = value2 - value1;
 
-            if (value < 0)
-            {
-                ((SolidBrush)fillBrush).Color = negativeColor;
-            }
-            else
-            {
-                ((SolidBrush)fillBrush).Color = fillColor;
-            }
+            ((SolidBrush)fillBrush).Color = (value < 0) ? negativeColor : fillColor;
 
             var rect = new RectangleF(
                 x: (float)settings.GetPixelX(edge1),
@@ -188,14 +181,7 @@ namespace ScottPlot
             double value2 = Math.Max(valueBase, value) + yOffset;
             double valueSpan = value2 - value1;
 
-            if (value < 0)
-            {
-                ((SolidBrush)fillBrush).Color = negativeColor;
-            }
-            else
-            {
-                ((SolidBrush)fillBrush).Color = fillColor;
-            }
+            ((SolidBrush)fillBrush).Color = (value < 0) ? negativeColor : fillColor;
 
             var rect = new RectangleF(
                 x: (float)settings.GetPixelX(value1),


### PR DESCRIPTION
New contributors should review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#463

**New functionality (code):**
Provide a code example demonstrating new functionality achieved with this pull request (if applicable):

```cs
Random rand = new Random(0);
int pointCount = 10;
double[] xs = DataGen.Consecutive(pointCount);
double[] ys = DataGen.RandomNormal(rand, pointCount, 5, 10);
double[] yOffsets = Enumerable.Range(0, pointCount).Select(count => ys.Take(count).Sum()).ToArray();

plt.PlotBar(xs, ys, yOffsets: yOffsets);
```

**New functionality (image):**
![image](https://user-images.githubusercontent.com/8635304/85477584-d5261580-b577-11ea-8fb5-0e6734364817.png)


# Opinion Wanted:
I wonder if `PlottableBar` should take a delegate to decide the colour of the bar, something like this:

```cs
Func<double y1, double y2, System.Drawing.Color> delegate = y2 - y1 > 0 ? System.Drawing.Color.Green : System.Drawing.Color.Red;
```

I photoshopped it to emulate the behaviour:
![image](https://user-images.githubusercontent.com/8635304/85477445-8f694d00-b577-11ea-98c6-00054b86adfe.png)

I like this personally, however this seems niche and could cause trouble for the legend, as one plottable would be multiple colours.


**Autoformat your code:**
The build will fail if your code is not auto-formatted. Auto-format your code in Visual Studio, or from the console using these commands:
```
cd ScottPlot/src/
dotnet tool install --global dotnet-format
dotnet format
```
