### PR TITLE
Implement missing minRenderIndex and maxRenderIndex for PlottableSignalXY

### DIFF
--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -82,7 +82,7 @@ namespace ScottPlot
         {
             double yMin = ys[minRenderIndex];
             double yMax = ys[minRenderIndex];
-            for (int i = minRenderIndex; i <= maxRenderIndex; i++)
+            for (int i = minRenderIndex + 1; i <= maxRenderIndex; i++)
             {
                 // TODO: ignore NaN
                 if (ys[i] < yMin) yMin = ys[i];

--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -80,9 +80,9 @@ namespace ScottPlot
 
         public override Config.AxisLimits2D GetLimits()
         {
-            double yMin = ys[0];
-            double yMax = ys[0];
-            for (int i = minRenderIndex; i < maxRenderIndex; i++)
+            double yMin = ys[minRenderIndex];
+            double yMax = ys[minRenderIndex];
+            for (int i = minRenderIndex; i <= maxRenderIndex; i++)
             {
                 // TODO: ignore NaN
                 if (ys[i] < yMin) yMin = ys[i];

--- a/src/ScottPlot/plottables/PlottableSignalXY.cs
+++ b/src/ScottPlot/plottables/PlottableSignalXY.cs
@@ -32,7 +32,7 @@ namespace ScottPlot
         public override AxisLimits2D GetLimits()
         {
             var limits = base.GetLimits();
-            limits.SetX(xs[0], xs[xs.Length - 1]);
+            limits.SetX(xs[minRenderIndex], xs[maxRenderIndex]);
             return limits;
         }
 

--- a/src/ScottPlot/plottables/PlottableSignalXY.cs
+++ b/src/ScottPlot/plottables/PlottableSignalXY.cs
@@ -60,11 +60,11 @@ namespace ScottPlot
             int? PointBeforeDisplayedIndex = null;
             int? PointAfterDisplayedIndex = null;
 
-            int CurrentIndex = 0;
+            int CurrentIndex = minRenderIndex;
             int[] xBordersIndexes = new int[settings.dataSize.Width + 1]; // indexes of points close to pixels borders
             for (int i = 0; i < settings.dataSize.Width + 1; i++)
             {
-                for (; CurrentIndex < xs.Length && xs[CurrentIndex] < xBorders[i]; CurrentIndex++)
+                for (; CurrentIndex <= maxRenderIndex && xs[CurrentIndex] < xBorders[i]; CurrentIndex++)
                     ;
 
                 if (PointBeforeDisplayedIndex == null) // point index before first pixel column
@@ -80,7 +80,7 @@ namespace ScottPlot
             // Draw lines
             if (PointsToDraw.Count > 1)
                 settings.gfxData.DrawLines(penHD, PointsToDraw.ToArray());
-            else if (xs[0] > xBorders[0] && xs[xs.Length - 1] < xBorders[xBorders.Length - 1])
+            else if (xs[minRenderIndex] > xBorders[0] && xs[maxRenderIndex] < xBorders[xBorders.Length - 1])
                 settings.gfxData.DrawLine(penHD,
                     settings.GetPixel(xs[0], ys.Min()),
                     settings.GetPixel(xs[0], ys.Max()));
@@ -176,7 +176,7 @@ namespace ScottPlot
         {
             List<PointF> PointsToDraw = new List<PointF>();
 
-            if (PointBeforeDisplayedIndex >= 0)
+            if (PointBeforeDisplayedIndex >= minRenderIndex)
             {
                 PointsToDraw.Add(settings.GetPixel(xs[PointBeforeDisplayedIndex.Value], ys[PointBeforeDisplayedIndex.Value]));
             }
@@ -195,7 +195,7 @@ namespace ScottPlot
                 }
             }
 
-            if (PointAfterDisplayedIndex < xs.Length && PointsToDraw.Count >= 1)
+            if (PointAfterDisplayedIndex <= maxRenderIndex && PointsToDraw.Count >= 1)
             {
                 PointF lastPoint = PointsToDraw[PointsToDraw.Count - 1];
                 PointF afterPoint = settings.GetPixel(xs[PointAfterDisplayedIndex.Value], ys[PointAfterDisplayedIndex.Value]);
@@ -205,7 +205,7 @@ namespace ScottPlot
                 PointsToDraw.Add(new PointF(x1, y1));
             }
 
-            if (PointBeforeDisplayedIndex >= 0 && PointsToDraw.Count >= 2)
+            if (PointBeforeDisplayedIndex >= minRenderIndex && PointsToDraw.Count >= 2)
             {
                 float x0 = -1;
                 float y0 = PointsToDraw[1].Y + (PointsToDraw[0].Y - PointsToDraw[1].Y) * (x0 - PointsToDraw[1].X) / (PointsToDraw[0].X - PointsToDraw[1].X);


### PR DESCRIPTION
**Purpose:**
Implement missing `minRenderIndex` and `maxRenderInde`x for `PlottableSignalXY` #493 
This PR use this params to render only part of data inside provided range.
All checks are done in the base `PlottableSignal` constructor

Additional fix wrong y limits calculation in `PlottableSignal` bdf0e9b

**New functionality (code):**
```c#
double[] x = DataGen.Consecutive(100_000);
double[] data = DataGen.RandomWalk(rand, 100_000);
formsPlot1.plt.PlotSignalXY(x, data, minRenderIndex: 4000, maxRenderIndex: 5000);
```

**New functionality (image):**
![image](https://user-images.githubusercontent.com/53831487/88689741-8a159a00-d103-11ea-9904-cfcd4d7056ad.png)




