### PR TITLE
SignalXY support for parallel processing and render index limits

### DIFF
--- a/src/ScottPlot/plottables/PlottableSignal.cs
+++ b/src/ScottPlot/plottables/PlottableSignal.cs
@@ -80,9 +80,9 @@ namespace ScottPlot
 
         public override Config.AxisLimits2D GetLimits()
         {
-            double yMin = ys[0];
-            double yMax = ys[0];
-            for (int i = minRenderIndex; i < maxRenderIndex; i++)
+            double yMin = ys[minRenderIndex];
+            double yMax = ys[minRenderIndex];
+            for (int i = minRenderIndex + 1; i <= maxRenderIndex; i++)
             {
                 // TODO: ignore NaN
                 if (ys[i] < yMin) yMin = ys[i];


### PR DESCRIPTION
**Purpose:**
Parallel processing for `PlottableSignalXY` #419
For now `PlottableSignalXY` support `useParallel` flag to enable/disable parallel processing.
Existing code has been substantially reworked, to make it unrelated between iterations and  without parallel/sequental code duplicates. Similar to the `PlottableSignal` #454 approach
Binary search is now used to find indexes in `xs` array. This should also improve performance.
`PlottableSignalXY` now respects to `minRenderIndex` and `maxRenderIndex` #493.  PR #495 deprecated now.

Additionaly fix `PlottableSignal` limits calculations.

**New functionality (code):**

```cs
plt.PlotSignalXY(xs, ys, minRenderIndex: 4000, maxRenderIndex: 200000, useParallel: true);
```

**New functionality (image):**

![image](https://user-images.githubusercontent.com/53831487/89446272-faa06480-d75c-11ea-9b98-618d6ca387ff.png)

