### PR TITLE
Donut pie chart

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -5,6 +5,7 @@
 * Holding shift while left-click-dragging the edge of a span moves it instead of resizing it (#509) _Thanks @Torgano_
 * CSV export is now culture invariant for improved support on systems where commas are decimal separators (#512) _Thanks Daniel_
 * Fix bug that occurred when calling GetLegendBitmap() before the plot was rendered (#527) _Thanks @el-aasi_
+* Pie charts now have an optional hollow center to produce donut plots (#534) _Thanks @Benny121221 and @AlexFsmn_
 
 ## ScottPlot 4.0.39
 * Legend now reflects LineStyle of Signal and SignalXY plots (#488) _Thanks @Benny121221_

--- a/src/ScottPlot.Demo/PlotTypes/Pie.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Pie.cs
@@ -77,6 +77,7 @@ namespace ScottPlot.Demo.PlotTypes
                 pie.donutSize = .6;
                 pie.centerText = centerText;
                 pie.centerTextColor = color1;
+                pie.outlineSize = 2;
                 pie.colors = new Color[] { color1, color2 };
 
                 plt.Grid(false);

--- a/src/ScottPlot.Demo/PlotTypes/Pie.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Pie.cs
@@ -41,6 +41,23 @@ namespace ScottPlot.Demo.PlotTypes
             }
         }
 
+        public class DonutPie : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Donut Pie";
+            public string description { get; } = "There is an option to have a \"donut\" pie chart.";
+
+            public void Render(Plot plt)
+            {
+                double[] values = { 778, 283, 184, 76, 43 };
+
+                plt.PlotPie(values, explodedChart: true, donut: true);
+
+                plt.Grid(false);
+                plt.Frame(false);
+                plt.Ticks(false, false);
+            }
+        }
+
         public class PieShowValues : PlotDemo, IPlotDemo
         {
             public string name { get; } = "Show Values";

--- a/src/ScottPlot.Demo/PlotTypes/Pie.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Pie.cs
@@ -50,7 +50,8 @@ namespace ScottPlot.Demo.PlotTypes
             {
                 double[] values = { 778, 283, 184, 76, 43 };
 
-                plt.PlotPie(values, explodedChart: true, donut: true);
+                //Default donutSize = 0.6
+                plt.PlotPie(values, explodedChart: true, donut: true, donutSize: 0.55);
 
                 plt.Grid(false);
                 plt.Frame(false);

--- a/src/ScottPlot.Demo/PlotTypes/Pie.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Pie.cs
@@ -70,7 +70,7 @@ namespace ScottPlot.Demo.PlotTypes
 
                 System.Drawing.Color[] colors = new System.Drawing.Color[] { System.Drawing.Color.FromArgb(255, 0, 150, 200), System.Drawing.Color.FromArgb(100, 0, 150, 200) };
 
-                plt.PlotPie(values, donut: true, showPercentageInDonut: true, colors: colors);
+                plt.PlotPie(values, donut: true, showPercentageInDonut: true, colors: colors, drawOutline: false);
 
                 plt.Grid(false);
                 plt.Frame(false);

--- a/src/ScottPlot.Demo/PlotTypes/Pie.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Pie.cs
@@ -59,6 +59,25 @@ namespace ScottPlot.Demo.PlotTypes
             }
         }
 
+        public class DonutPieWithPercentageInDonut : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Donut Pie With Percentage in the Middle";
+            public string description { get; } = "There is an option to have a \"donut\" pie chart with the largest proportion in the donut hole.";
+
+            public void Render(Plot plt)
+            {
+                double[] values = { 778, 586 };
+
+                System.Drawing.Color[] colors = new System.Drawing.Color[] { System.Drawing.Color.FromArgb(255, 0, 150, 200), System.Drawing.Color.FromArgb(100, 0, 150, 200) };
+
+                plt.PlotPie(values, donut: true, showPercentageInDonut: true, colors: colors);
+
+                plt.Grid(false);
+                plt.Frame(false);
+                plt.Ticks(false, false);
+            }
+        }
+
         public class PieShowValues : PlotDemo, IPlotDemo
         {
             public string name { get; } = "Show Values";

--- a/src/ScottPlot.Demo/PlotTypes/Pie.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Pie.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 
@@ -43,15 +44,15 @@ namespace ScottPlot.Demo.PlotTypes
 
         public class DonutPie : PlotDemo, IPlotDemo
         {
-            public string name { get; } = "Donut Pie";
-            public string description { get; } = "There is an option to have a \"donut\" pie chart.";
+            public string name { get; } = "Donut Plot";
+            public string description { get; } = "Donut plots are circle plots with a hollow center.";
 
             public void Render(Plot plt)
             {
                 double[] values = { 778, 283, 184, 76, 43 };
 
-                //Default donutSize = 0.6
-                plt.PlotPie(values, explodedChart: true, donut: true, donutSize: 0.55);
+                var pie = plt.PlotPie(values);
+                pie.donutSize = .6;
 
                 plt.Grid(false);
                 plt.Frame(false);
@@ -61,16 +62,22 @@ namespace ScottPlot.Demo.PlotTypes
 
         public class DonutPieWithPercentageInDonut : PlotDemo, IPlotDemo
         {
-            public string name { get; } = "Donut Pie With Percentage in the Middle";
-            public string description { get; } = "There is an option to have a \"donut\" pie chart with the largest proportion in the donut hole.";
+            public string name { get; } = "Donut Plot With Text";
+            public string description { get; } = "Custom text can be displayed inside the donut.";
 
             public void Render(Plot plt)
             {
-                double[] values = { 778, 586 };
+                double[] values = { 779, 586 };
+                string centerText = $"{values[0] / values.Sum() * 100:00.0}%";
 
-                System.Drawing.Color[] colors = new System.Drawing.Color[] { System.Drawing.Color.FromArgb(255, 0, 150, 200), System.Drawing.Color.FromArgb(100, 0, 150, 200) };
+                Color color1 = Color.FromArgb(255, 0, 150, 200);
+                Color color2 = Color.FromArgb(100, 0, 150, 200);
 
-                plt.PlotPie(values, donut: true, showPercentageInDonut: true, colors: colors, drawOutline: false);
+                var pie = plt.PlotPie(values);
+                pie.donutSize = .6;
+                pie.centerText = centerText;
+                pie.centerTextColor = color1;
+                pie.colors = new Color[] { color1, color2 };
 
                 plt.Grid(false);
                 plt.Frame(false);

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1142,13 +1142,14 @@ namespace ScottPlot
             string label = null,
             bool donut = false,
             double donutSize = 0.6,
-            bool showPercentageInDonut = false
+            bool showPercentageInDonut = false,
+            bool drawOutline = true
             )
         {
             if (colors is null)
                 colors = Enumerable.Range(0, values.Length).Select(i => settings.colorset.GetColor(i)).ToArray();
 
-            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut, donutSize, showPercentageInDonut);
+            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut, donutSize, showPercentageInDonut, drawOutline);
 
             settings.plottables.Add(pie);
             return pie;

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1141,13 +1141,14 @@ namespace ScottPlot
             bool showLabels = true,
             string label = null,
             bool donut = false,
-            double donutSize = 0.6
+            double donutSize = 0.6,
+            bool showPercentageInDonut = false
             )
         {
             if (colors is null)
                 colors = Enumerable.Range(0, values.Length).Select(i => settings.colorset.GetColor(i)).ToArray();
 
-            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut, donutSize);
+            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut, donutSize, showPercentageInDonut);
 
             settings.plottables.Add(pie);
             return pie;

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1139,13 +1139,14 @@ namespace ScottPlot
             bool showValues = false,
             bool showPercentages = false,
             bool showLabels = true,
-            string label = null
+            string label = null,
+            bool donut = false
             )
         {
             if (colors is null)
                 colors = Enumerable.Range(0, values.Length).Select(i => settings.colorset.GetColor(i)).ToArray();
 
-            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label);
+            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut);
 
             settings.plottables.Add(pie);
             return pie;

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1140,13 +1140,14 @@ namespace ScottPlot
             bool showPercentages = false,
             bool showLabels = true,
             string label = null,
-            bool donut = false
+            bool donut = false,
+            double donutSize = 0.6
             )
         {
             if (colors is null)
                 colors = Enumerable.Range(0, values.Length).Select(i => settings.colorset.GetColor(i)).ToArray();
 
-            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut);
+            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut, donutSize);
 
             settings.plottables.Add(pie);
             return pie;

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -1139,17 +1139,13 @@ namespace ScottPlot
             bool showValues = false,
             bool showPercentages = false,
             bool showLabels = true,
-            string label = null,
-            bool donut = false,
-            double donutSize = 0.6,
-            bool showPercentageInDonut = false,
-            bool drawOutline = true
+            string label = null
             )
         {
             if (colors is null)
                 colors = Enumerable.Range(0, values.Length).Select(i => settings.colorset.GetColor(i)).ToArray();
 
-            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label, donut, donutSize, showPercentageInDonut, drawOutline);
+            PlottablePie pie = new PlottablePie(values, sliceLabels, colors, explodedChart, showValues, showPercentages, showLabels, label);
 
             settings.plottables.Add(pie);
             return pie;

--- a/src/ScottPlot/plottables/PlottablePie.cs
+++ b/src/ScottPlot/plottables/PlottablePie.cs
@@ -20,11 +20,12 @@ namespace ScottPlot
         bool showLabels;
         bool donut;
         double donutSize;
+        bool showPercentageInDonut;
 
         private SolidBrush brush = new SolidBrush(Color.Black);
         private Pen pen = new Pen(Color.Black);
 
-        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label, bool donut, double donutSize)
+        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label, bool donut, double donutSize, bool showPercentageInDonut)
         {
             this.values = values;
             this.label = label;
@@ -36,6 +37,7 @@ namespace ScottPlot
             this.showLabels = (groupNames is null) ? false : showLabels;
             this.donut = donut;
             this.donutSize = donutSize;
+            this.showPercentageInDonut = showPercentageInDonut;
         }
 
         public override LegendItem[] GetLegendItems()
@@ -113,7 +115,7 @@ namespace ScottPlot
                 labelXs[i] = (boundingRectangle.X + diameterPixels / 2 + xOffset + Math.Cos(angle) * sliceLabelR);
                 labelYs[i] = (boundingRectangle.Y + diameterPixels / 2 + yOffset + Math.Sin(angle) * sliceLabelR);
                 string sliceLabelValue = (showValues) ? $"{values[i]}" : "";
-                string sliceLabelPercentage = (showPercentages) ? $"{proportions[i] * 100:f1}%" : "";
+                string sliceLabelPercentage = (showPercentages && !showPercentageInDonut) ? $"{proportions[i] * 100:f1}%" : "";
                 string sliceLabelName = (showLabels) ? groupNames[i] : "";
                 labelStrings[i] = $"{sliceLabelValue}\n{sliceLabelPercentage}\n{sliceLabelName}".Trim();
 
@@ -144,6 +146,22 @@ namespace ScottPlot
             settings.gfxData.DrawEllipse(pen, boundingRectangle.X, boundingRectangle.Y, boundingRectangle.Width, boundingRectangle.Height);
 
             settings.gfxData.ResetClip();
+
+            if (showPercentageInDonut)
+            {
+                int maxPercentageIndex = 0;
+                for (int i = 1; i < proportions.Length; i++)
+                {
+                    if (proportions[i] > proportions[maxPercentageIndex])
+                    {
+                        maxPercentageIndex = i;
+                    }
+                }
+                int maxPercentage = (int)Math.Round(proportions[maxPercentageIndex] * 100);
+                brush.Color = colors[maxPercentageIndex];
+                Font donutHoleFont = new Font(fontName, 36);
+                settings.gfxData.DrawString($"{maxPercentage}%", donutHoleFont, brush, settings.GetPixel(0, 0), settings.misc.sfCenterCenter);
+            }
         }
 
         public override string ToString()

--- a/src/ScottPlot/plottables/PlottablePie.cs
+++ b/src/ScottPlot/plottables/PlottablePie.cs
@@ -22,6 +22,7 @@ namespace ScottPlot
         public float outlineSize = 0;
         public Color outlineColor = Color.Black;
         public string centerText;
+        public float centerTextSize = 36;
         public Color centerTextColor = Color.Black;
 
         private SolidBrush brush = new SolidBrush(Color.Black);
@@ -153,8 +154,9 @@ namespace ScottPlot
             if (centerText != null)
             {
                 brush.Color = centerTextColor;
-                Font donutHoleFont = new Font(fontName, 36);
+                Font donutHoleFont = new Font(fontName, centerTextSize);
                 settings.gfxData.DrawString(centerText, donutHoleFont, brush, settings.GetPixel(0, 0), settings.misc.sfCenterCenter);
+                donutHoleFont.Dispose();
             }
         }
 

--- a/src/ScottPlot/plottables/PlottablePie.cs
+++ b/src/ScottPlot/plottables/PlottablePie.cs
@@ -141,6 +141,8 @@ namespace ScottPlot
 
             pen.Width = outlineWidth;
             settings.gfxData.DrawEllipse(pen, boundingRectangle.X, boundingRectangle.Y, boundingRectangle.Width, boundingRectangle.Height);
+
+            settings.gfxData.ResetClip();
         }
 
         public override string ToString()

--- a/src/ScottPlot/plottables/PlottablePie.cs
+++ b/src/ScottPlot/plottables/PlottablePie.cs
@@ -19,11 +19,12 @@ namespace ScottPlot
         bool showPercentages;
         bool showLabels;
         bool donut;
+        double donutSize;
 
         private SolidBrush brush = new SolidBrush(Color.Black);
         private Pen pen = new Pen(Color.Black);
 
-        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label, bool donut)
+        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label, bool donut, double donutSize)
         {
             this.values = values;
             this.label = label;
@@ -34,6 +35,7 @@ namespace ScottPlot
             this.showPercentages = showPercentages;
             this.showLabels = (groupNames is null) ? false : showLabels;
             this.donut = donut;
+            this.donutSize = donutSize;
         }
 
         public override LegendItem[] GetLegendItems()
@@ -89,8 +91,7 @@ namespace ScottPlot
             if (donut)
             {
                 GraphicsPath graphicsPath = new GraphicsPath();
-                const float donutFactor = 0.6f; // Proportion of the pie's diameter to be clipped by the donut hole
-                float donutDiameterPixels = donutFactor * diameterPixels;
+                float donutDiameterPixels = (float)donutSize * diameterPixels;
                 RectangleF donutHoleBoundingRectangle = new RectangleF((float)settings.GetPixelX(centreX) - donutDiameterPixels / 2, (float)settings.GetPixelY(centreY) - donutDiameterPixels / 2, donutDiameterPixels, donutDiameterPixels);
                 graphicsPath.AddEllipse(donutHoleBoundingRectangle);
                 Region excludedRegion = new Region(graphicsPath);

--- a/src/ScottPlot/plottables/PlottablePie.cs
+++ b/src/ScottPlot/plottables/PlottablePie.cs
@@ -21,11 +21,12 @@ namespace ScottPlot
         bool donut;
         double donutSize;
         bool showPercentageInDonut;
+        bool drawOutline;
 
         private SolidBrush brush = new SolidBrush(Color.Black);
         private Pen pen = new Pen(Color.Black);
 
-        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label, bool donut, double donutSize, bool showPercentageInDonut)
+        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label, bool donut, double donutSize, bool showPercentageInDonut, bool drawOutline)
         {
             this.values = values;
             this.label = label;
@@ -38,6 +39,7 @@ namespace ScottPlot
             this.donut = donut;
             this.donutSize = donutSize;
             this.showPercentageInDonut = showPercentageInDonut;
+            this.drawOutline = drawOutline;
         }
 
         public override LegendItem[] GetLegendItems()
@@ -143,6 +145,12 @@ namespace ScottPlot
             }
 
             pen.Width = outlineWidth;
+
+            if (!drawOutline && !explodedChart)
+            {
+                pen.Color = System.Drawing.Color.Transparent;
+            }
+
             settings.gfxData.DrawEllipse(pen, boundingRectangle.X, boundingRectangle.Y, boundingRectangle.Width, boundingRectangle.Height);
 
             settings.gfxData.ResetClip();

--- a/src/ScottPlot/plottables/PlottablePie.cs
+++ b/src/ScottPlot/plottables/PlottablePie.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Text;
 using ScottPlot.Config;
@@ -17,11 +18,12 @@ namespace ScottPlot
         bool showValues;
         bool showPercentages;
         bool showLabels;
+        bool donut;
 
         private SolidBrush brush = new SolidBrush(Color.Black);
         private Pen pen = new Pen(Color.Black);
 
-        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label)
+        public PlottablePie(double[] values, string[] groupNames, Color[] colors, bool explodedChart, bool showValues, bool showPercentages, bool showLabels, string label, bool donut)
         {
             this.values = values;
             this.label = label;
@@ -31,6 +33,7 @@ namespace ScottPlot
             this.showValues = showValues;
             this.showPercentages = showPercentages;
             this.showLabels = (groupNames is null) ? false : showLabels;
+            this.donut = donut;
         }
 
         public override LegendItem[] GetLegendItems()
@@ -82,6 +85,17 @@ namespace ScottPlot
             string[] labelStrings = new string[values.Length];
 
             RectangleF boundingRectangle = new RectangleF((float)settings.GetPixelX(centreX) - diameterPixels / 2, (float)settings.GetPixelY(centreY) - diameterPixels / 2, diameterPixels, diameterPixels);
+
+            if (donut)
+            {
+                GraphicsPath graphicsPath = new GraphicsPath();
+                const float donutFactor = 0.6f; // Proportion of the pie's diameter to be clipped by the donut hole
+                float donutDiameterPixels = donutFactor * diameterPixels;
+                RectangleF donutHoleBoundingRectangle = new RectangleF((float)settings.GetPixelX(centreX) - donutDiameterPixels / 2, (float)settings.GetPixelY(centreY) - donutDiameterPixels / 2, donutDiameterPixels, donutDiameterPixels);
+                graphicsPath.AddEllipse(donutHoleBoundingRectangle);
+                Region excludedRegion = new Region(graphicsPath);
+                settings.gfxData.ExcludeClip(excludedRegion);
+            }
 
             double start = -90;
             for (int i = 0; i < values.Length; i++)


### PR DESCRIPTION
New contributors should review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#533

**New functionality (code):**
Provide a code example demonstrating new functionality achieved with this pull request (if applicable):

```cs
plt.PlotPie(values, donut: true);
```

**New functionality (image):**
If this pull request changes how a plot is rendered, provide an image or screenshot demonstrating the new functionality:
![image](https://user-images.githubusercontent.com/8635304/92336255-e9988b00-f05b-11ea-99fc-5bd4e3afc1fd.png)
Note this screenshot uses both an exploded and a donutted pie chart.

**Autoformat your code:**
The build will fail if your code is not auto-formatted. Auto-format your code in Visual Studio, or from the console using these commands:
```
cd ScottPlot/src/
dotnet tool install --global dotnet-format
dotnet format
```
