### PR TITLE
Improve mouse wheel zoom speed

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -8,6 +8,7 @@
 * Fix bug that occurred when calling GetLegendBitmap() before the plot was rendered (#527) _Thanks @el-aasi_
 * Pie charts now have an optional hollow center to produce donut plots (#534) _Thanks @Benny121221 and @AlexFsmn_
 * Added electrocardiogram (ECG) simulator to the DataGen module (#540) _Thanks @AteCoder_
+* Improved mouse scroll wheel responsiveness by delaying high quality render (#545, #543) _@Thanks StendProg_
 
 ## ScottPlot 4.0.39
 * Legend now reflects LineStyle of Signal and SignalXY plots (#488) _Thanks @Benny121221_

--- a/src/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -450,6 +450,14 @@ namespace ScottPlot
 
         #region mouse clicking
 
+        private readonly DispatcherTimer MouseWheelHQRenderTimer = new DispatcherTimer();
+
+        private void MouseWheelHQRenderTimerTick(object sender, object o)
+        {
+            Render(lowQuality: false, recalculateLayout: false);
+            (sender as DispatcherTimer).Stop();
+        }
+
         private void UserControl_MouseWheel(object sender, MouseWheelEventArgs e)
         {
             if (enableScrollWheelZoom == false)
@@ -465,9 +473,20 @@ namespace ScottPlot
 
             plt.AxisZoom(xFrac, yFrac, plt.CoordinateFromPixelX(mousePixel.X), plt.CoordinateFromPixelY(mousePixel.Y));
             AxisChanged?.Invoke(null, null);
+
             bool shouldRecalculate = recalculateLayoutOnMouseUp ?? plotContainsHeatmap == false;
-            Render(recalculateLayout: shouldRecalculate);
+            Render(lowQuality: true, recalculateLayout: shouldRecalculate);
+
+            // do the setup here so we don't have to in the constructors
+            MouseWheelHQRenderTimer.Interval = new TimeSpan(0, 0, 0, 0, 500);
+            MouseWheelHQRenderTimer.Tick -= MouseWheelHQRenderTimerTick;
+            MouseWheelHQRenderTimer.Tick += MouseWheelHQRenderTimerTick;
+
+            // abort previous running timers and restart
+            MouseWheelHQRenderTimer.Stop();
+            MouseWheelHQRenderTimer.Start();
         }
+
 
         private void UserControl_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {

--- a/src/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -163,6 +163,8 @@ namespace ScottPlot
         private double middleClickMarginX = .1;
         private double middleClickMarginY = .1;
         private bool? recalculateLayoutOnMouseUp = null;
+        private bool lowQualityOnScrollWheel = true;
+        private int lowQualityScrollWheelDelay = 500;
         public void Configure(
             bool? enablePanning = null,
             bool? enableRightClickZoom = null,
@@ -176,7 +178,9 @@ namespace ScottPlot
             bool? equalAxes = null,
             double? middleClickMarginX = null,
             double? middleClickMarginY = null,
-            bool? recalculateLayoutOnMouseUp = null
+            bool? recalculateLayoutOnMouseUp = null,
+            bool? lowQualityOnScrollWheel = null,
+            int? lowQualityScrollWheelDelay = null
             )
         {
             if (enablePanning != null) this.enablePanning = (bool)enablePanning;
@@ -192,6 +196,8 @@ namespace ScottPlot
             this.middleClickMarginX = middleClickMarginX ?? this.middleClickMarginX;
             this.middleClickMarginY = middleClickMarginY ?? this.middleClickMarginY;
             this.recalculateLayoutOnMouseUp = recalculateLayoutOnMouseUp;
+            this.lowQualityOnScrollWheel = lowQualityOnScrollWheel ?? this.lowQualityOnScrollWheel;
+            this.lowQualityScrollWheelDelay = lowQualityScrollWheelDelay ?? this.lowQualityScrollWheelDelay;
         }
 
         private bool isAltPressed { get { return Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt); } }
@@ -475,16 +481,17 @@ namespace ScottPlot
             AxisChanged?.Invoke(null, null);
 
             bool shouldRecalculate = recalculateLayoutOnMouseUp ?? plotContainsHeatmap == false;
-            Render(lowQuality: true, recalculateLayout: shouldRecalculate);
+            Render(lowQuality: lowQualityOnScrollWheel, recalculateLayout: shouldRecalculate);
 
             // do the setup here so we don't have to in the constructors
-            MouseWheelHQRenderTimer.Interval = new TimeSpan(0, 0, 0, 0, 500);
+            MouseWheelHQRenderTimer.Interval = new TimeSpan(0, 0, 0, 0, lowQualityScrollWheelDelay);
             MouseWheelHQRenderTimer.Tick -= MouseWheelHQRenderTimerTick;
             MouseWheelHQRenderTimer.Tick += MouseWheelHQRenderTimerTick;
 
             // abort previous running timers and restart
             MouseWheelHQRenderTimer.Stop();
-            MouseWheelHQRenderTimer.Start();
+            if (lowQualityOnScrollWheel)
+                MouseWheelHQRenderTimer.Start();
         }
 
 


### PR DESCRIPTION
**Purpose:**
Greatly improve render speed for `ScrollWheel` interactions #543.
1. Fix multiple event handler subscibe bug (`Control.Reset`).
2. All Scroll Wheel events puts in Render requests queue. At the end of the current rendering, all new requests are selected, the axes are scaled for each request, and then a new render is started. All renders are done in low quality. If no new request is received within 500 ms, then high quality rendering starts.

The code is durty, and shoud be refactored. But the functionality can already be tested.

**New functionality (code):**
There is no new `API` for now. But control settings like `HQDelayTime`, `LQDuringScrollWheel` should appear.

**New functionality (image):**
![FastZoom](https://user-images.githubusercontent.com/53831487/93257338-5c64dd00-f7a5-11ea-8da8-84dc2b3893b8.gif)
