### PR TITLE
Improve mouse wheel zoom speed (WPF control)

### DIFF
--- a/src/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -467,14 +467,6 @@ namespace ScottPlot
             return null;
         }
 
-        private readonly DispatcherTimer MouseWheelHQRenderTimer = new DispatcherTimer();
-
-        private void MouseWheelHQRenderTimerTick(object sender, object o)
-        {
-            Render(lowQuality: false, recalculateLayout: false);
-            (sender as DispatcherTimer).Stop();
-        }
-
         private readonly Queue<MouseWheelEventArgs> MouseWheelEvents = new Queue<MouseWheelEventArgs>();
         private readonly Stopwatch ScrollWheelTimer = new Stopwatch();
         public async void ScrollWheelProcessor()

--- a/src/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot.WinForms/FormsPlot.cs
@@ -430,7 +430,7 @@ namespace ScottPlot
             base.OnMouseDoubleClick(e);
         }
 
-        private readonly List<MouseEventArgs> MouseWheelEvents = new List<MouseEventArgs>();
+        private readonly Queue<MouseEventArgs> MouseWheelEvents = new Queue<MouseEventArgs>();
         private readonly Stopwatch ScrollWheelTimer = new Stopwatch();
         public void ScrollWheelProcessor()
         {
@@ -444,11 +444,10 @@ namespace ScottPlot
                     Application.DoEvents();
                     continue;
                 }
-
                 // if new mouse events, apply them and reset the timer
-                int currentRequestCount = MouseWheelEvents.Count;
-                foreach (MouseEventArgs e in MouseWheelEvents.Take(currentRequestCount))
+                while (MouseWheelEvents.Count > 0)
                 {
+                    MouseEventArgs e = MouseWheelEvents.Dequeue();
                     double xFrac = (e.Delta > 0) ? 1.15 : 0.85;
                     double yFrac = (e.Delta > 0) ? 1.15 : 0.85;
 
@@ -457,8 +456,6 @@ namespace ScottPlot
 
                     plt.AxisZoom(xFrac, yFrac, plt.CoordinateFromPixelX(e.Location.X), plt.CoordinateFromPixelY(e.Location.Y));
                 }
-
-                MouseWheelEvents.RemoveRange(0, currentRequestCount); // TODO check for thread safety
 
                 bool shouldRecalculate = recalculateLayoutOnMouseUp ?? plotContainsHeatmap == false;
                 Render(lowQuality: lowQualityOnScrollWheel, recalculateLayout: shouldRecalculate, processEvents: true);
@@ -480,7 +477,7 @@ namespace ScottPlot
 
             base.OnMouseWheel(e);
 
-            MouseWheelEvents.Add(e);
+            MouseWheelEvents.Enqueue(e);
             if (ScrollWheelTimer.IsRunning == false)
                 ScrollWheelProcessor();
         }


### PR DESCRIPTION
**Purpose:**
Continuing a #545 .
1. Implement the same Render queue for WPF Control.
2. Small refactoring.
3. WPF Control `Render()` now have `bool processEvents` argument like WinForms Control. Improve WPF control pan/zoom speed.

**New functionality (code):**
```c#
WPFControl.Configure(lowQualityOnScrollWheel: true, lowQualityScrollWheelDelay: 500);
Render(processEvents: true);
```