### PR TITLE
PlottableSignalConst now return correct TreesReady flag.

### DIFF
--- a/src/ScottPlot/MinMaxSearchStrategies/SegmentedTreeMinMaxSearchStrategy.cs
+++ b/src/ScottPlot/MinMaxSearchStrategies/SegmentedTreeMinMaxSearchStrategy.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using ScottPlot.DataStructures;
+﻿using ScottPlot.DataStructures;
+using System;
 
 namespace ScottPlot.MinMaxSearchStrategies
 {
@@ -7,6 +7,7 @@ namespace ScottPlot.MinMaxSearchStrategies
     {
         private SegmentedTree<T> segmentedTree;
 
+        public bool TreesReady => segmentedTree.TreesReady;
         public SegmentedTreeMinMaxSearchStrategy()
         {
             segmentedTree = new SegmentedTree<T>();

--- a/src/ScottPlot/plottables/PlottableSignalBase.cs
+++ b/src/ScottPlot/plottables/PlottableSignalBase.cs
@@ -15,7 +15,6 @@ namespace ScottPlot
     public class PlottableSignalBase<T> : Plottable, IExportable where T : struct, IComparable
     {
         protected IMinMaxSearchStrategy<T> minmaxSearchStrategy;
-        // Any changes must be sync with PlottableSignal
         public T[] ys;
         public double sampleRate;
         public double samplePeriod;
@@ -41,7 +40,6 @@ namespace ScottPlot
         public Color? gradientFillColor2;
         public int baseline;
 
-        public bool TreesReady => true;
         public PlottableSignalBase(T[] ys, double sampleRate, double xOffset, double yOffset, Color color,
             double lineWidth, double markerSize, string label, Color[] colorByDensity,
             int minRenderIndex, int maxRenderIndex, LineStyle lineStyle, bool useParallel,

--- a/src/ScottPlot/plottables/PlottableSignalConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalConst.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using ScottPlot.MinMaxSearchStrategies;
+using System;
 using System.Drawing;
-using ScottPlot.MinMaxSearchStrategies;
 
 namespace ScottPlot
 {
@@ -13,7 +13,7 @@ namespace ScottPlot
     // - source array can be change by call updateData(), updating by ranges much faster.
     public class PlottableSignalConst<T> : PlottableSignalBase<T> where T : struct, IComparable
     {
-        public bool TreesReady => true;
+        public bool TreesReady => (minmaxSearchStrategy as SegmentedTreeMinMaxSearchStrategy<T>)?.TreesReady ?? false;
         public PlottableSignalConst(T[] ys, double sampleRate, double xOffset, double yOffset, Color color,
             double lineWidth, double markerSize, string label, Color[] colorByDensity,
             int minRenderIndex, int maxRenderIndex, LineStyle lineStyle, bool useParallel)

--- a/src/ScottPlot/plottables/PlottableSignalXYConst.cs
+++ b/src/ScottPlot/plottables/PlottableSignalXYConst.cs
@@ -6,6 +6,7 @@ namespace ScottPlot
 {
     public class PlottableSignalXYConst<TX, TY> : PlottableSignalXYGeneric<TX, TY> where TX : struct, IComparable where TY : struct, IComparable
     {
+        public bool TreesReady => (minmaxSearchStrategy as SegmentedTreeMinMaxSearchStrategy<TY>)?.TreesReady ?? false;
         public PlottableSignalXYConst(TX[] xs, TY[] ys, Color color, double lineWidth, double markerSize, string label, int minRenderIndex, int maxRenderIndex, LineStyle lineStyle, bool useParallel, IMinMaxSearchStrategy<TY> minMaxSearchStrategy = null)
             : base(xs, ys, color, lineWidth, markerSize, label, minRenderIndex, maxRenderIndex, lineStyle, useParallel, new SegmentedTreeMinMaxSearchStrategy<TY>())
         {


### PR DESCRIPTION
**Purpose:**
Small additional fix to #504.
For now `PlottableSignalConst` and`PlottableSignaXYConst` returns correct `TreesReady` flag. `PlottableSignalBase` don't contain `TreesReady` flag.

The presence of this flag in the `PlottableSignal` is still doubtful, since the current implementation locks the current thread at the time the trees are calculated. As a result, if you poll `TreesReady` from the current thread, then there will always be `true`.

There is api and it's easy to do: Run trees calculation on another thread, and dont lock creation of `PlottableSignalConst`. Before trees calculated it rendered as `PlottableSignal`. When I did #504 I made the decision that this behavior was useless (discussable).