### PR TITLE
All DateTimeTick units return 2 lines labels.

### DIFF
--- a/src/ScottPlot/Config/DateTimeTickUnits/DateTimeUnitFactory.cs
+++ b/src/ScottPlot/Config/DateTimeTickUnits/DateTimeUnitFactory.cs
@@ -44,21 +44,23 @@ namespace ScottPlot.Config.DateTimeTickUnits
         {
             double daysApart = to.ToOADate() - from.ToOADate();
 
+            int halfDensity = maxTickCount / 2;
+
             // tick unit borders in days
             var tickUnitBorders = new List<(DateTimeUnit kind, double border)?>
             {
-                (DateTimeUnit.ThousandYear, 365 * 1_000 * 2),
-                (DateTimeUnit.HundredYear, 365 * 100 * 2),
-                (DateTimeUnit.TenYear, 365 * 10 * 2),
-                (DateTimeUnit.Year, 365 * 2),
-                (DateTimeUnit.Month, 30 * 2),
-                (DateTimeUnit.Day, 1 * 2),
-                (DateTimeUnit.Hour, 1.0 / 24 * 2),
-                (DateTimeUnit.Minute, 1.0 / 24 / 60 * 2),
-                (DateTimeUnit.Second, 1.0 / 24 / 3600 * 2),
-                (DateTimeUnit.Decisecond, 1.0 / 24 / 3600 / 10 * 2),
-                (DateTimeUnit.Centisecond, 1.0 / 24 / 3600 / 100 * 2),
-                (DateTimeUnit.Millisecond, 1.0 / 24 / 3600 / 1000 * 2),
+                (DateTimeUnit.ThousandYear, 365 * 1_000 * halfDensity),
+                (DateTimeUnit.HundredYear, 365 * 100 * halfDensity),
+                (DateTimeUnit.TenYear, 365 * 10 * halfDensity),
+                (DateTimeUnit.Year, 365 * halfDensity),
+                (DateTimeUnit.Month, 30 * halfDensity),
+                (DateTimeUnit.Day, 1 * halfDensity),
+                (DateTimeUnit.Hour, 1.0 / 24 * halfDensity),
+                (DateTimeUnit.Minute, 1.0 / 24 / 60 * halfDensity),
+                (DateTimeUnit.Second, 1.0 / 24 / 3600 * halfDensity),
+                (DateTimeUnit.Decisecond, 1.0 / 24 / 3600 / 10 * halfDensity),
+                (DateTimeUnit.Centisecond, 1.0 / 24 / 3600 / 100 * halfDensity),
+                (DateTimeUnit.Millisecond, 1.0 / 24 / 3600 / 1000 * halfDensity),
             };
 
             var bestTickUnitKind = tickUnitBorders.FirstOrDefault(tr => daysApart > tr.Value.border);

--- a/src/ScottPlot/Config/DateTimeTickUnits/MonthToMinutes/DateTimeTickDay.cs
+++ b/src/ScottPlot/Config/DateTimeTickUnits/MonthToMinutes/DateTimeTickDay.cs
@@ -9,7 +9,7 @@ namespace ScottPlot.Config.DateTimeTickUnits
         {
             kind = DateTimeUnit.Day;
             if (manualSpacing == null)
-                deltas = new int[] { 1, 2, 5, 10 };
+                deltas = new int[] { 1, 2, 5, 10, 20 };
         }
 
         protected override DateTime Floor(DateTime value)

--- a/src/ScottPlot/Config/DateTimeTickUnits/MonthToMinutes/DateTimeTickMonth.cs
+++ b/src/ScottPlot/Config/DateTimeTickUnits/MonthToMinutes/DateTimeTickMonth.cs
@@ -26,7 +26,12 @@ namespace ScottPlot.Config.DateTimeTickUnits
         {
             var dt = new DateTime(value.Year, value.Month, 1);
             string localizedLabel = dt.ToString("Y", culture); // year and month pattern
-            return localizedLabel.Replace(" ", "\n") + "\n ";
+            // replace only first space " "
+            int pos = localizedLabel.IndexOf(" ");
+            if (pos < 0)
+                return localizedLabel + "\n";
+            else
+                return localizedLabel.Substring(0, pos) + "\n" + localizedLabel.Substring(pos + 1, localizedLabel.Length - pos - 1);
         }
     }
 }

--- a/tests/Ticks/DateTimeTicksTests.cs
+++ b/tests/Ticks/DateTimeTicksTests.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using ScottPlot.Config.DateTimeTickUnits;
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace ScottPlotTests.Ticks
+{
+    [TestFixture]
+    public class DateTimeTicksTests
+    {
+        [Test, Explicit]
+        public void GetTicksAndLabels_AllUnitsAndAllCultures_AllLabelsContains2Lines()
+        {
+            DateTime from = DateTime.Now;
+            CultureInfo[] cultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
+                                    // This cultures support only short date range (100 Year) and throws on test
+                                    .Where(culture => culture.ToString() != "ar" && culture.ToString() != "ar-SA")
+                                    .ToArray();
+            DateTimeUnitFactory factory = new DateTimeUnitFactory();
+            for (DateTime to = from + TimeSpan.FromDays(1000 * 365); to - from > TimeSpan.FromMilliseconds(1); to -= (to - from) / 2)
+            {
+                foreach (var culture in cultures)
+                {
+                    var unit = factory.CreateBestUnit(from, to, culture, 10);
+                    var labels = unit.GetTicksAndLabels(from, to, null);
+                    Assert.False(labels.Labels.Any(l => l.Count(c => c == '\n') != 1));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Purpose:**
`DateTimeTickMonth` now always return 2 lines labels for any `Culture`. #539

Only first space replaced with `newLine`. It can divide a month that is described in few words in some cultures, But it's better then previous behavior.

Additionally fix #564 bug.