### PR TITLE
Nice hexnumbers

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -6,6 +6,7 @@
 * Improved appearance of semi-transparent legend items (#567)
 * Improved tick labels for ticks smaller than 1E-5 (#568) _Thanks @ozgur640_
 * Improved support for Avalonia 0.10 (#571) _Thanks @Benny121221 and @apkrymov_
+* Improved positions for base16 ticks (#582, #581) _Thanks @Benny121221_
 
 ## ScottPlot 4.0.42
 * Improved DPI scaling support when using WinForms in .NET Core applications (#563) _Thanks @citizen3942_

--- a/src/ScottPlot/Config/TickCollection.cs
+++ b/src/ScottPlot/Config/TickCollection.cs
@@ -139,14 +139,14 @@ namespace ScottPlot.Config
                 low = settings.axes.y.min - settings.yAxisUnitsPerPixel; // add an extra pixel to capture the edge tick
                 high = settings.axes.y.max + settings.yAxisUnitsPerPixel; // add an extra pixel to capture the edge tick
                 maxTickCount = (int)(settings.dataSize.Height / maxLabelSize.Height);
-                tickSpacing = (settings.ticks.manualSpacingY != 0) ? settings.ticks.manualSpacingY : GetIdealTickSpacing(low, high, maxTickCount);
+                tickSpacing = (settings.ticks.manualSpacingY != 0) ? settings.ticks.manualSpacingY : GetIdealTickSpacing(low, high, maxTickCount, radix);
             }
             else
             {
                 low = settings.axes.x.min - settings.xAxisUnitsPerPixel; // add an extra pixel to capture the edge tick
                 high = settings.axes.x.max + settings.xAxisUnitsPerPixel; // add an extra pixel to capture the edge tick
                 maxTickCount = (int)(settings.dataSize.Width / maxLabelSize.Width * 1.2);
-                tickSpacing = (settings.ticks.manualSpacingX != 0) ? settings.ticks.manualSpacingX : GetIdealTickSpacing(low, high, maxTickCount);
+                tickSpacing = (settings.ticks.manualSpacingX != 0) ? settings.ticks.manualSpacingX : GetIdealTickSpacing(low, high, maxTickCount, radix);
             }
 
             // now that tick spacing is known, populate the list of ticks and labels
@@ -191,16 +191,18 @@ namespace ScottPlot.Config
             return $"Tick Collection: [{allTickLabels}] {cornerLabel}";
         }
 
-        private static double GetIdealTickSpacing(double low, double high, int maxTickCount)
+        private static readonly double[] DivByDecimal = { 2, 2, 2.5 }; // dividing from 10 yields 5, 2.5, and 1.
+        private static readonly double[] DivByHexadecimal = { 2, 2, 2, 2 }; // dividing from 16 yields 8, 4, 2, and 1.
+        private static double GetIdealTickSpacing(double low, double high, int maxTickCount, int radix = 10)
         {
             double range = high - low;
-            int exponent = (int)Math.Log10(range);
-            List<double> tickSpacings = new List<double>() { Math.Pow(10, exponent) };
+            int exponent = (int)Math.Log(range, radix);
+            List<double> tickSpacings = new List<double>() { Math.Pow(radix, exponent) };
             tickSpacings.Add(tickSpacings.Last());
             tickSpacings.Add(tickSpacings.Last());
 
             int divisions = 0;
-            double[] divBy = new double[] { 2, 2, 2.5 }; // dividing from 10 yields 5, 2.5, and 1.
+            double[] divBy = radix == 16 ? DivByHexadecimal : DivByDecimal;
 
             while (true)
             {

--- a/src/ScottPlot/Config/TickCollection.cs
+++ b/src/ScottPlot/Config/TickCollection.cs
@@ -1,6 +1,8 @@
 ﻿using ScottPlot.Config.DateTimeTickUnits;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
@@ -191,8 +193,6 @@ namespace ScottPlot.Config
             return $"Tick Collection: [{allTickLabels}] {cornerLabel}";
         }
 
-        private static readonly double[] DivByDecimal = { 2, 2, 2.5 }; // dividing from 10 yields 5, 2.5, and 1.
-        private static readonly double[] DivByHexadecimal = { 2, 2, 2, 2 }; // dividing from 16 yields 8, 4, 2, and 1.
         private static double GetIdealTickSpacing(double low, double high, int maxTickCount, int radix = 10)
         {
             double range = high - low;
@@ -201,15 +201,20 @@ namespace ScottPlot.Config
             tickSpacings.Add(tickSpacings.Last());
             tickSpacings.Add(tickSpacings.Last());
 
-            int divisions = 0;
-            double[] divBy = radix == 16 ? DivByHexadecimal : DivByDecimal;
+            double[] divBy;
+            if (radix == 10)
+                divBy = new double[] { 2, 2, 2.5 }; // 10, 5, 2.5, 1
+            else if (radix == 16)
+                divBy = new double[] { 2, 2, 2, 2 }; // 16, 8, 4, 2, 1
+            else
+                throw new ArgumentException($"radix {radix} is not supported");
 
-            while (true)
+            int divisions = 0;
+            int tickCount = 0;
+            while ((tickCount < maxTickCount) && (tickSpacings.Count < 1000))
             {
                 tickSpacings.Add(tickSpacings.Last() / divBy[divisions++ % divBy.Length]);
-                int tickCount = (int)(range / tickSpacings.Last());
-                if ((tickCount > maxTickCount) || (tickSpacings.Count > 1000))
-                    break;
+                tickCount = (int)(range / tickSpacings.Last());
             }
 
             return tickSpacings[tickSpacings.Count - 3];

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -419,7 +419,7 @@ namespace ScottPlot
             }
 
             char[] symbols = "0123456789ABCDEF".ToCharArray();
-            if (radix > symbols.Length || radix <= 0)
+            if (radix > symbols.Length || radix <= 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(radix));
             }

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -456,6 +456,10 @@ namespace ScottPlot
 
             if (decimalLength != 0)
             {
+                if (output == "")
+                {
+                    output += "0";
+                }
                 output += ".";
                 output += ToDifferentBase(Math.Round(decimalPart * Math.Pow(radix, decimalPlaces)), radix, decimalPlaces, decimalPlaces);
                 if (dropTrailingZeroes)

--- a/src/ScottPlot/Tools.cs
+++ b/src/ScottPlot/Tools.cs
@@ -406,6 +406,7 @@ namespace ScottPlot
             return output;
         }
 
+
         public static string ToDifferentBase(double number, int radix = 16, int decimalPlaces = 3, int padInteger = 0, bool dropTrailingZeroes = true)
         {
             if (number < 0)
@@ -418,7 +419,7 @@ namespace ScottPlot
             }
 
             char[] symbols = "0123456789ABCDEF".ToCharArray();
-            if (radix > symbols.Length)
+            if (radix > symbols.Length || radix <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(radix));
             }
@@ -437,7 +438,14 @@ namespace ScottPlot
 
             for (int i = 0; i < integerLength; i++)
             {
-                output = symbols[(int)(number % radix)] + output;
+                if (number == radix && padInteger == 0)
+                {
+                    output = "10" + output;
+                }
+                else
+                {
+                    output = symbols[(int)(number % radix)] + output;
+                }
                 number /= radix;
             }
 

--- a/tests/Cookbook/Chef.cs
+++ b/tests/Cookbook/Chef.cs
@@ -21,7 +21,7 @@ namespace ScottPlot.Tests.Cookbook
             Console.WriteLine("Generating cookbook in: " + reportGen.outputFolder);
 
             reportGen.ClearFolders();
-            foreach (IPlotDemo recipe in reportGen.recipes.Where( r => r.categoryMajor != "DataDiagnostic"))
+            foreach (IPlotDemo recipe in reportGen.recipes.Where(r => r.categoryMajor != "DataDiagnostic"))
             {
                 Console.WriteLine($"Generating {recipe}...");
                 reportGen.CreateImage(recipe);

--- a/tests/Tools/ChangingBase.cs
+++ b/tests/Tools/ChangingBase.cs
@@ -70,6 +70,7 @@ namespace ScottPlotTests.Tools
         [TestCase(100, 17)] //If we add extra symbols (i.e. base64) this will no longer throw
         [TestCase(100, -1)]
         [TestCase(100, 0)]
+        [TestCase(100, 1)]
         public void TestOutOfRange(double number, int radix)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => ScottPlot.Tools.ToDifferentBase(number, radix));

--- a/tests/Tools/ChangingBase.cs
+++ b/tests/Tools/ChangingBase.cs
@@ -16,6 +16,7 @@ namespace ScottPlotTests.Tools
         [TestCase(-0, 2, "0")]
         [TestCase(0x10000000, 16, "10000000")]
         [TestCase(0x20000000, 16, "20000000")]
+        [TestCase(0x21, 16, "21")]
 
         [TestCase(-255, 16, "-FF")]
         [TestCase(-112, 16, "-70")]
@@ -24,6 +25,7 @@ namespace ScottPlotTests.Tools
         [TestCase(-15, 2, "-1111")]
         [TestCase(-0x10000000, 16, "-10000000")]
         [TestCase(-0x20000000, 16, "-20000000")]
+        [TestCase(-0x21, 16, "-21")]
 
         public void TestIntegers(double number, int radix, string expectedOutput)
         {
@@ -42,7 +44,9 @@ namespace ScottPlotTests.Tools
         [TestCase(255.3, 2, 9, false, "11111111.010011010")]
         [TestCase(255.3, 16, 1, true, "FF.5")]
         [TestCase(255.3, 2, 1, true, "11111111")]
-        [TestCase(268435456.00390625, 16, 5, true, "10000000.021")]
+        [TestCase(268435456.008056640625, 16, 5, true, "10000000.021")]
+        [TestCase(0.008056640625, 16, 5, true, "0.021")]
+
 
         [TestCase(-200.1, 16, 3, true, "-C8.19A")]
         [TestCase(-200.1, 16, 9, true, "-C8.19999999A")]
@@ -56,7 +60,8 @@ namespace ScottPlotTests.Tools
         [TestCase(-255.3, 2, 9, false, "-11111111.010011010")]
         [TestCase(-255.3, 16, 1, true, "-FF.5")]
         [TestCase(-255.3, 2, 1, true, "-11111111")]
-        [TestCase(-268435456.00390625, 16, 5, true, "-10000000.021")]
+        [TestCase(-268435456.008056640625, 16, 5, true, "-10000000.021")]
+        [TestCase(-0.008056640625, 16, 5, true, "-0.021")]
         public void TestDecimals(double number, int radix, int decimalPlaces, bool dropTrailingZeroes, string expectedOutput)
         {
             Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces, dropTrailingZeroes: dropTrailingZeroes));

--- a/tests/Tools/ChangingBase.cs
+++ b/tests/Tools/ChangingBase.cs
@@ -14,12 +14,16 @@ namespace ScottPlotTests.Tools
         [TestCase(15, 2, "1111")]
         [TestCase(0, 2, "0")]
         [TestCase(-0, 2, "0")]
+        [TestCase(0x10000000, 16, "10000000")]
+        [TestCase(0x20000000, 16, "20000000")]
 
         [TestCase(-255, 16, "-FF")]
         [TestCase(-112, 16, "-70")]
         [TestCase(-127, 16, "-7F")]
         [TestCase(-255, 2, "-11111111")]
         [TestCase(-15, 2, "-1111")]
+        [TestCase(-0x10000000, 16, "-10000000")]
+        [TestCase(-0x20000000, 16, "-20000000")]
 
         public void TestIntegers(double number, int radix, string expectedOutput)
         {
@@ -38,6 +42,7 @@ namespace ScottPlotTests.Tools
         [TestCase(255.3, 2, 9, false, "11111111.010011010")]
         [TestCase(255.3, 16, 1, true, "FF.5")]
         [TestCase(255.3, 2, 1, true, "11111111")]
+        [TestCase(268435456.00390625, 16, 5, true, "10000000.021")]
 
         [TestCase(-200.1, 16, 3, true, "-C8.19A")]
         [TestCase(-200.1, 16, 9, true, "-C8.19999999A")]
@@ -51,15 +56,18 @@ namespace ScottPlotTests.Tools
         [TestCase(-255.3, 2, 9, false, "-11111111.010011010")]
         [TestCase(-255.3, 16, 1, true, "-FF.5")]
         [TestCase(-255.3, 2, 1, true, "-11111111")]
+        [TestCase(-268435456.00390625, 16, 5, true, "-10000000.021")]
         public void TestDecimals(double number, int radix, int decimalPlaces, bool dropTrailingZeroes, string expectedOutput)
         {
             Assert.AreEqual(expectedOutput, ScottPlot.Tools.ToDifferentBase(number, radix, decimalPlaces, dropTrailingZeroes: dropTrailingZeroes));
         }
 
-        [Test]
-        public void TestOutOfRange()
+        [TestCase(100, 17)] //If we add extra symbols (i.e. base64) this will no longer throw
+        [TestCase(100, -1)]
+        [TestCase(100, 0)]
+        public void TestOutOfRange(double number, int radix)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => ScottPlot.Tools.ToDifferentBase(10, 17));//If we add extra symbols (i.e. base64) this will no longer throw
+            Assert.Throws<ArgumentOutOfRangeException>(() => ScottPlot.Tools.ToDifferentBase(number, radix));
         }
     }
 }


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#581 

**New Functionality:**
This is a comparison from the cookbook. Note that the only radices which currently have "nice" numbers are decimal and hexadecimal.

Before:
![image](https://user-images.githubusercontent.com/8635304/95160558-22607880-075e-11eb-9075-8f8220424e45.png)

After:
![image](https://user-images.githubusercontent.com/8635304/95160657-563b9e00-075e-11eb-90c7-f99fd2e43c67.png)

**Other Concerns**
I noticed when writing this PR that in some situations the helper function `ScottPlot.Tools.ToDifferentBase` gave wrong answers, most noticeably in the case of numbers of the form r^k where r is the radix and k is some integer. It's hard to notice these cases when the numbers are not nice because the odds of that number also being a nice number in decimal are low; therefore it will not show up on the tick labels.