### PR TITLE
Fixes DataDiagnostic breaking cookbook generation

### DIFF
--- a/dev/devops/ScottPlotDevTools/Program.cs
+++ b/dev/devops/ScottPlotDevTools/Program.cs
@@ -82,8 +82,11 @@ namespace ScottPlotDevTools
             var recipes = ScottPlot.Demo.Reflection.GetPlots();
             foreach (var recipe in recipes)
             {
-                Console.Write(".");
-                reportGeneratpr.CreateImage(recipe);
+                if (recipe.categoryMinor != "DataDiagnostic")
+                {
+                    Console.Write(".");
+                    reportGeneratpr.CreateImage(recipe);
+                }
             }
             Console.WriteLine();
 

--- a/src/ScottPlot.Demo/DataDiagnostic/DataDiagnostic.cs
+++ b/src/ScottPlot.Demo/DataDiagnostic/DataDiagnostic.cs
@@ -13,7 +13,7 @@ namespace ScottPlot.Demo.DataDiagnostic
             public string name => "SignalContainNAN";
 
             // TODO make good description
-            public string description => "Data values containing NAN values can be catched using DiagnosticMode";
+            public string description => "Data values containing NAN values can be caught using DiagnosticMode";
 
             public void Render(Plot plt)
             {
@@ -38,7 +38,7 @@ namespace ScottPlot.Demo.DataDiagnostic
         {
             // TODO make good name/description
             public string name { get; } = "Signal with X and Y data";
-            public string description { get; } = "After 5 seconds wrong data writed to xs array, this can be catch on Render with DiagnosticMode";
+            public string description { get; } = "After 5 seconds wrong data writed to xs array, this can be caught on Render with DiagnosticMode";
 
             public void Render(Plot plt)
             {
@@ -58,7 +58,7 @@ namespace ScottPlot.Demo.DataDiagnostic
                 plt.Title($"SignalXY Plot ({pointCount:N0} points)");
                 plt.PlotSignalXY(xs, ys);
 
-                // Check goes only on Render, so user must interract with plot after 5 seconds
+                // Check only happens on Render, so user must interract with plot after 5 seconds
                 Task.Run(() =>
                   {
                       Thread.Sleep(5000);
@@ -71,7 +71,7 @@ namespace ScottPlot.Demo.DataDiagnostic
         {
             // TODO make good name/description
             public string name { get; } = "Scatter with 1000 Points";
-            public string description { get; } = "After 5 seconds wrong data writed to xs array, this can be catch on Render with DiagnosticMode";
+            public string description { get; } = "After 5 seconds wrong data writed to xs array, this can be caught on Render with DiagnosticMode";
 
             public void Render(Plot plt)
             {
@@ -91,7 +91,7 @@ namespace ScottPlot.Demo.DataDiagnostic
                 plt.Title($"ScatterPlot ({pointCount:N0} points)");
                 var scatter = plt.PlotScatter(xs, ys);
 
-                // Check goes only on Render, so user must interract with plot after 5 seconds
+                // Check only happens on Render, so user must interract with plot after 5 seconds
                 Task.Run(() =>
                   {
                       Thread.Sleep(5000);

--- a/src/ScottPlot.Demo/ReportGenerator.cs
+++ b/src/ScottPlot.Demo/ReportGenerator.cs
@@ -116,7 +116,11 @@ namespace ScottPlot.Demo
                 md.AppendLine($"### {title}\n\n");
                 md.AppendLine($"{description}\n\n");
                 md.AppendLine($"```cs\n{sourceCode}\n```\n\n");
-                md.AppendLine($"![](images/{recipe.id}.png)\n\n");
+
+                if (recipe.categoryMinor != "DataDiagnostic")
+                {
+                    md.AppendLine($"![](images/{recipe.id}.png)\n\n");
+                }
             }
 
             md.Insert(0, $"## Table of Contents\n\n![](TOC)\n\n");

--- a/tests/Cookbook/Chef.cs
+++ b/tests/Cookbook/Chef.cs
@@ -21,7 +21,7 @@ namespace ScottPlot.Tests.Cookbook
             Console.WriteLine("Generating cookbook in: " + reportGen.outputFolder);
 
             reportGen.ClearFolders();
-            foreach (IPlotDemo recipe in reportGen.recipes.Where( r => r.categoryMajor != "DataDiagnostic"))
+            foreach (IPlotDemo recipe in reportGen.recipes.Where(r => r.categoryMajor != "DataDiagnostic"))
             {
                 Console.WriteLine($"Generating {recipe}...");
                 reportGen.CreateImage(recipe);


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
The DataDiagnostic demos through exceptions (as they're supposed to), however, this means that generating the cookbook will always fail. This change stops the dev tools from trying to render these, so the cookbook entry includes only the description and the source code. There are also some minor grammatical fixes.

**New Functionality:**
N/A