### PR TITLE
Adds hatched fills to PlotFill, PlotFillAboveBelow, etc

### DIFF
--- a/src/ScottPlot.Demo/PlotTypes/Fill.cs
+++ b/src/ScottPlot.Demo/PlotTypes/Fill.cs
@@ -26,6 +26,31 @@ namespace ScottPlot.Demo.PlotTypes
             }
         }
 
+        public class FillHatchBeneathCurve : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Filled Curve (Hatch)";
+            public string description { get; } = "You can create a filled scatter plot where the area between the curve and baseline is shaded with a color. The baseline defaults to 0, but can be set with an optional argument.";
+
+            public void Render(Plot plt)
+            {
+                double[] xs = DataGen.Range(0, 10, .1, true);
+                double[] sin = DataGen.Sin(xs);
+                double[] cos = DataGen.Cos(xs);
+
+                var sinCurve = plt.PlotFill(xs, sin, "sin", lineWidth: 2, fillAlpha: .5);
+                var cosCurve = plt.PlotFill(xs, cos, "cos", lineWidth: 2, fillAlpha: .5);
+
+                sinCurve.hatchStyle = Drawing.HatchStyle.StripedDownwardDiagonal;
+                sinCurve.hatchColor = Color.Transparent; // This is the default
+                cosCurve.hatchStyle = Drawing.HatchStyle.StripedUpwardDiagonal;
+                cosCurve.hatchColor = Color.Transparent;
+
+                plt.PlotHLine(0, color: Color.Black);
+                plt.AxisAuto(0);
+                plt.Legend(location: legendLocation.lowerLeft);
+            }
+        }
+
         public class FillBetweenCurves : PlotDemo, IPlotDemo
         {
             public string name { get; } = "Fill Between Curves";
@@ -45,6 +70,26 @@ namespace ScottPlot.Demo.PlotTypes
             }
         }
 
+        public class FillHatchBetweenCurves : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Fill Between Curves (Hatch)";
+            public string description { get; } = "You can fill the area between curves by supplying two pairs of X/Y coordinates";
+
+            public void Render(Plot plt)
+            {
+                double[] xs = DataGen.Range(0, 10, .1, true);
+                double[] sin = DataGen.Sin(xs);
+                double[] cos = DataGen.Cos(xs);
+
+                var filledRegion = plt.PlotFill(xs, sin, xs, cos, fillAlpha: .5);
+                filledRegion.hatchStyle = Drawing.HatchStyle.StripedUpwardDiagonal;
+                plt.PlotScatter(xs, sin, Color.Black);
+                plt.PlotScatter(xs, cos, Color.Black);
+
+                plt.AxisAuto(0);
+            }
+        }
+
         public class FillAboveBelow : PlotDemo, IPlotDemo
         {
             public string name { get; } = "Fill Above and Below";
@@ -57,6 +102,29 @@ namespace ScottPlot.Demo.PlotTypes
                 var xs = ScottPlot.DataGen.Consecutive(ys.Length, spacing: 0.025);
 
                 plt.PlotFillAboveBelow(xs, ys, fillAlpha: .5, labelAbove: "above", labelBelow: "below");
+                plt.Legend(location: ScottPlot.legendLocation.lowerLeft);
+                plt.AxisAuto(0);
+            }
+        }
+
+        public class FillHatchAboveBelow : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Fill Above and Below (Hatch)";
+            public string description { get; } = "A special method lets you create a filled line plot with different colors above/below the baseline.";
+
+            public void Render(Plot plt)
+            {
+                Random rand = new Random(0);
+                var ys = ScottPlot.DataGen.RandomWalk(rand, 1000, offset: -10);
+                var xs = ScottPlot.DataGen.Consecutive(ys.Length, spacing: 0.025);
+
+                (var filledBelow, var filledAbove) = plt.PlotFillAboveBelow(xs, ys, labelAbove: "above", labelBelow: "below");
+                filledAbove.hatchStyle = Drawing.HatchStyle.StripedWideDownwardDiagonal;
+                filledAbove.hatchColor = Color.LightGreen;
+
+                filledBelow.hatchStyle = Drawing.HatchStyle.StripedWideUpwardDiagonal;
+                filledBelow.hatchColor = Color.LightPink;
+
                 plt.Legend(location: ScottPlot.legendLocation.lowerLeft);
                 plt.AxisAuto(0);
             }

--- a/src/ScottPlot/Plot/Plot.PlotPolygon.cs
+++ b/src/ScottPlot/Plot/Plot.PlotPolygon.cs
@@ -3,6 +3,7 @@
  *   - Long lists of optional arguments (matplotlib style) are permitted.
  *   - Use one line per argument to simplify the tracking of changes.
  */
+using ScottPlot.Drawing;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -23,7 +24,9 @@ namespace ScottPlot
             bool fill = true,
             Color? fillColor = null,
             double fillAlpha = 1,
-            double baseline = 0
+            double baseline = 0,
+            Color? hatchColor = null,
+            HatchStyle hatchStyle = HatchStyle.None
             )
         {
             if (xs.Length != ys.Length)
@@ -32,7 +35,7 @@ namespace ScottPlot
             double[] xs2 = Tools.Pad(xs, cloneEdges: true);
             double[] ys2 = Tools.Pad(ys, padWithLeft: baseline, padWithRight: baseline);
 
-            return PlotPolygon(xs2, ys2, label, lineWidth, lineColor, fill, fillColor, fillAlpha);
+            return PlotPolygon(xs2, ys2, label, lineWidth, lineColor, fill, fillColor, fillAlpha, hatchColor, hatchStyle);
         }
 
         public PlottablePolygon PlotFill(
@@ -46,7 +49,9 @@ namespace ScottPlot
             bool fill = true,
             Color? fillColor = null,
             double fillAlpha = 1,
-            double baseline = 0
+            double baseline = 0,
+            Color? hatchColor = null,
+            HatchStyle hatchStyle = HatchStyle.None
             )
         {
             if ((xs1.Length != ys1.Length) || (xs2.Length != ys2.Length))
@@ -67,7 +72,7 @@ namespace ScottPlot
                 bothY[ys1.Length + i] = ys2[ys2.Length - 1 - i];
             }
 
-            return PlotPolygon(bothX, bothY, label, lineWidth, lineColor, fill, fillColor, fillAlpha);
+            return PlotPolygon(bothX, bothY, label, lineWidth, lineColor, fill, fillColor, fillAlpha, hatchColor, hatchStyle);
         }
 
         public (PlottablePolygon, PlottablePolygon) PlotFillAboveBelow(
@@ -81,7 +86,9 @@ namespace ScottPlot
             Color? fillColorAbove = null,
             Color? fillColorBelow = null,
             double fillAlpha = 1,
-            double baseline = 0
+            double baseline = 0,
+            Color? hatchColor = null,
+            HatchStyle hatchStyle = HatchStyle.None
             )
         {
             if (xs.Length != ys.Length)
@@ -113,8 +120,8 @@ namespace ScottPlot
             if (lineColor is null)
                 lineColor = Color.Black;
 
-            var polyAbove = PlotPolygon(xs2, ys2above, labelAbove, lineWidth, lineColor, fill, fillColorAbove, fillAlpha);
-            var polyBelow = PlotPolygon(xs2, ys2below, labelBelow, lineWidth, lineColor, fill, fillColorBelow, fillAlpha);
+            var polyAbove = PlotPolygon(xs2, ys2above, labelAbove, lineWidth, lineColor, fill, fillColorAbove, fillAlpha, hatchColor, hatchStyle);
+            var polyBelow = PlotPolygon(xs2, ys2below, labelBelow, lineWidth, lineColor, fill, fillColorBelow, fillAlpha, hatchColor, hatchStyle);
 
             return (polyBelow, polyAbove);
         }
@@ -127,7 +134,9 @@ namespace ScottPlot
             Color? lineColor = null,
             bool fill = true,
             Color? fillColor = null,
-            double fillAlpha = 1
+            double fillAlpha = 1,
+            Color? hatchColor = null,
+            HatchStyle hatchStyle = HatchStyle.None
             )
         {
             var plottable = new PlottablePolygon(xs, ys)
@@ -137,7 +146,9 @@ namespace ScottPlot
                 lineColor = lineColor ?? Color.Black,
                 fill = fill,
                 fillColor = fillColor ?? settings.GetNextColor(),
-                fillAlpha = fillAlpha
+                fillAlpha = fillAlpha,
+                hatchColor = hatchColor ?? System.Drawing.Color.Transparent,
+                hatchStyle = hatchStyle
             };
 
             Add(plottable);
@@ -151,7 +162,9 @@ namespace ScottPlot
             Color? lineColor = null,
             bool fill = true,
             Color? fillColor = null,
-            double fillAlpha = 1
+            double fillAlpha = 1,
+            Color? hatchColor = null,
+            HatchStyle hatchStyle = HatchStyle.None
             )
         {
             var plottable = new PlottablePolygons(polys)
@@ -161,7 +174,9 @@ namespace ScottPlot
                 lineColor = lineColor ?? Color.Black,
                 fill = fill,
                 fillColor = fillColor ?? settings.GetNextColor(),
-                fillAlpha = fillAlpha
+                fillAlpha = fillAlpha,
+                hatchColor = hatchColor ?? System.Drawing.Color.Transparent,
+                hatchStyle = hatchStyle
             };
 
             Add(plottable);

--- a/src/ScottPlot/plottables/PlottablePolygon.cs
+++ b/src/ScottPlot/plottables/PlottablePolygon.cs
@@ -18,6 +18,8 @@ namespace ScottPlot
         public bool fill = true;
         public Color fillColor = Color.Gray;
         public double fillAlpha = 0.5;
+        public Color hatchColor = Color.Transparent;
+        public HatchStyle hatchStyle = HatchStyle.None;
 
         public PlottablePolygon(double[] xs, double[] ys)
         {
@@ -58,7 +60,10 @@ namespace ScottPlot
                     color: fill ? fillColor : lineColor,
                     lineWidth: fill ? 10 : lineWidth,
                     markerShape: MarkerShape.none
-                )
+                ){
+                    hatchColor = hatchColor,
+                    hatchStyle = hatchStyle
+                }
             };
 
         public string ValidationErrorMessage { get; private set; }
@@ -98,7 +103,7 @@ namespace ScottPlot
                 points[i] = new PointF(dims.GetPixelX(xs[i]), dims.GetPixelY(ys[i]));
 
             using (Graphics gfx = GDI.Graphics(bmp, lowQuality))
-            using (Brush fillBrush = GDI.Brush(Color.FromArgb((byte)(255 * fillAlpha), fillColor)))
+            using (Brush fillBrush = hatchStyle == HatchStyle.None ? GDI.Brush(fillColor, fillAlpha) : GDI.Brush(fillColor, hatchColor: hatchColor, hatchStyle: hatchStyle))
             using (Pen outlinePen = GDI.Pen(lineColor, (float)lineWidth))
             {
                 if (fill)

--- a/src/ScottPlot/plottables/PlottablePolygons.cs
+++ b/src/ScottPlot/plottables/PlottablePolygons.cs
@@ -17,6 +17,8 @@ namespace ScottPlot
         public bool fill;
         public Color fillColor;
         public double fillAlpha;
+        public Color hatchColor = Color.Transparent;
+        public HatchStyle hatchStyle = HatchStyle.None;
 
         public bool SkipOffScreenPolygons = true;
         public bool RenderSmallPolygonsAsSinglePixels = true;
@@ -89,7 +91,10 @@ namespace ScottPlot
                     color: fill ? fillColor : lineColor,
                     lineWidth: fill ? 10 : lineWidth,
                     markerShape: MarkerShape.none
-                )
+                ){
+                    hatchColor = hatchColor,
+                    hatchStyle = hatchStyle
+                }
             };
 
         private bool IsBiggerThenPixel(List<(double x, double y)> poly, double UnitsPerPixelX, double UnitsPerPixelY)
@@ -135,7 +140,7 @@ namespace ScottPlot
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
             using (Graphics gfx = GDI.Graphics(bmp, lowQuality))
-            using (Brush brush = GDI.Brush(fillColor, fillAlpha))
+            using (Brush brush = hatchStyle == HatchStyle.None ? GDI.Brush(fillColor, fillAlpha) : GDI.Brush(fillColor, hatchColor: hatchColor, hatchStyle: hatchStyle))
             using (Pen pen = GDI.Pen(lineColor, lineWidth))
             {
                 foreach (List<(double x, double y)> poly in polys)


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Adds hatched/patterned fills to `PlotFill`, `PlotFillAboveBelow`, `PlotPolygon` and `PlotPolygons`.

**New Functionality:**
Describe what this pull request does using code and/or images.

This code:
```cs
                Random rand = new Random(0);
                var ys = ScottPlot.DataGen.RandomWalk(rand, 1000, offset: -10);
                var xs = ScottPlot.DataGen.Consecutive(ys.Length, spacing: 0.025);

                (var filledBelow, var filledAbove) = plt.PlotFillAboveBelow(xs, ys, labelAbove: "above", labelBelow: "below");
                filledAbove.hatchStyle = Drawing.HatchStyle.StripedWideDownwardDiagonal;
                filledAbove.hatchColor = Color.LightGreen;

                filledBelow.hatchStyle = Drawing.HatchStyle.StripedWideUpwardDiagonal;
                filledBelow.hatchColor = Color.LightPink;

                plt.Legend(location: ScottPlot.legendLocation.lowerLeft);
                plt.AxisAuto(0);
```
Produces this image:
![image](https://user-images.githubusercontent.com/8635304/98159252-79f71e80-1e99-11eb-91d6-1b0c6254234d.png)
