### PR TITLE
Radar multi axis

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,6 +1,7 @@
 # ScottPlot Changelog
 
 ## ScottPlot 4.1.0 ⚠️ in development
+* Additional customizations for radar charts (#634, #628) _Thanks @Benny121221_
 
 Work toward ScottPlot 4.1 began in October, 2020 and merged into the master branch one month later ([#605](https://github.com/swharden/ScottPlot/pull/605)). Improvements are focused at enhanced performance, improved thread safety, support for multiple axes, and options for data validation. See [roadmap.md](roadmap.md) for details.
 

--- a/src/ScottPlot/Plot/Plot.PlotMisc.cs
+++ b/src/ScottPlot/Plot/Plot.PlotMisc.cs
@@ -65,13 +65,14 @@ namespace ScottPlot
             string[] groupNames = null,
             Color[] fillColors = null,
             double fillAlpha = .4,
-            Color? webColor = null
+            Color? webColor = null,
+            bool independentAxes = false
             )
         {
             Color[] colors = fillColors ?? Enumerable.Range(0, values.Length).Select(i => settings.PlottablePalette.GetColor(i)).ToArray();
             Color[] colorsAlpha = colors.Select(x => Color.FromArgb((byte)(255 * fillAlpha), x)).ToArray();
 
-            var plottable = new RadarPlot(values, colors, fillColors ?? colorsAlpha)
+            var plottable = new RadarPlot(values, colors, fillColors ?? colorsAlpha, independentAxes)
             {
                 categoryNames = categoryNames,
                 groupNames = groupNames,

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -6,142 +6,202 @@ using ScottPlot.Drawing;
 
 namespace ScottPlot.Plottable
 {
-    public class RadarPlot : IPlottable
-    {
-        private readonly double[,] normalized;
-        private readonly double normalizedMax;
-        public string[] categoryNames;
-        public string[] groupNames;
-        public Color[] fillColors;
-        public Color[] lineColors;
-        public Color webColor;
-        public bool IsVisible { get; set; } = true;
-        public int HorizontalAxisIndex { get; set; } = 0;
-        public int VerticalAxisIndex { get; set; } = 0;
-        public Drawing.Font Font = new Drawing.Font();
+	public class RadarPlot : IPlottable
+	{
+		private readonly double[,] normalized;
+		private readonly double normalizedMax;
+		private readonly double[] normalizedMaxes;
+		public string[] categoryNames;
+		public string[] groupNames;
+		public Color[] fillColors;
+		public Color[] lineColors;
+		public Color webColor;
+		public readonly bool independentAxes;
+		public bool IsVisible { get; set; } = true;
+		public int HorizontalAxisIndex { get; set; } = 0;
+		public int VerticalAxisIndex { get; set; } = 0;
+		public Drawing.Font Font = new Drawing.Font();
 
-        public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors)
-        {
-            this.lineColors = lineColors;
-            this.fillColors = fillColors;
+		public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors, bool independentAxes)
+		{
+			this.lineColors = lineColors;
+			this.fillColors = fillColors;
+			this.independentAxes = independentAxes;
 
-            normalized = new double[values.GetLength(0), values.GetLength(1)];
-            Array.Copy(values, 0, normalized, 0, values.Length);
-            normalizedMax = NormalizeInPlace(normalized);
-        }
+			normalized = new double[values.GetLength(0), values.GetLength(1)];
+			Array.Copy(values, 0, normalized, 0, values.Length);
+			if (independentAxes)
+			{
+				normalizedMaxes = NormalizeSeveralInPlace(normalized);
+			}
+			else
+			{
+				normalizedMax = NormalizeInPlace(normalized);
+			}
+		}
 
-        public override string ToString() =>
-            $"PlottableRadar with {PointCount} points and {normalized.GetUpperBound(1) + 1} categories.";
+		public override string ToString() =>
+			$"PlottableRadar with {PointCount} points and {normalized.GetUpperBound(1) + 1} categories.";
 
-        public void ValidateData(bool deep = false)
-        {
-            if (groupNames != null && groupNames.Length != normalized.GetLength(0))
-                throw new InvalidOperationException("group names must match size of values");
+		public void ValidateData(bool deep = false)
+		{
+			if (groupNames != null && groupNames.Length != normalized.GetLength(0))
+				throw new InvalidOperationException("group names must match size of values");
 
-            if (categoryNames != null && categoryNames.Length != normalized.GetLength(1))
-                throw new InvalidOperationException("category names must match size of values");
-        }
+			if (categoryNames != null && categoryNames.Length != normalized.GetLength(1))
+				throw new InvalidOperationException("category names must match size of values");
+		}
 
-        /// <summary>
-        /// Normalize a 2D array by dividing all values by the maximum value.
-        /// </summary>
-        /// <returns>maximum value in the array before normalization</returns>
-        private double NormalizeInPlace(double[,] input)
-        {
-            double max = input[0, 0];
+		/// <summary>
+		/// Normalize a 2D array by dividing all values by the maximum value.
+		/// </summary>
+		/// <returns>maximum value in the array before normalization</returns>
+		private double NormalizeInPlace(double[,] input)
+		{
+			double max = input[0, 0];
 
-            for (int i = 0; i < input.GetLength(0); i++)
-                for (int j = 0; j < input.GetLength(1); j++)
-                    max = Math.Max(max, input[i, j]);
+			for (int i = 0; i < input.GetLength(0); i++)
+				for (int j = 0; j < input.GetLength(1); j++)
+					max = Math.Max(max, input[i, j]);
 
-            for (int i = 0; i < input.GetLength(0); i++)
-                for (int j = 0; j < input.GetLength(1); j++)
-                    input[i, j] /= max;
+			for (int i = 0; i < input.GetLength(0); i++)
+				for (int j = 0; j < input.GetLength(1); j++)
+					input[i, j] /= max;
 
-            return max;
-        }
+			return max;
+		}
 
-        public LegendItem[] GetLegendItems()
-        {
-            if (groupNames is null)
-                return null;
+		/// <summary>
+		/// Normalize each row of a 2D array independently by dividing all values by the maximum value.
+		/// </summary>
+		/// <returns>maximum value in each row of the array before normalization</returns>
+		private double[] NormalizeSeveralInPlace(double[,] input)
+		{
+			double[] maxes = new double[input.GetLength(1)];
+			for (int i = 0; i < input.GetLength(1); i++)
+			{
+				double max = input[0, i];
+				for (int j = 0; j < input.GetLength(0); j++)
+				{
+					max = Math.Max(input[j, i], max);
+				}
+				maxes[i] = max;
+			}
 
-            List<LegendItem> legendItems = new List<LegendItem>();
-            for (int i = 0; i < groupNames.Length; i++)
-            {
-                var item = new LegendItem()
-                {
-                    label = groupNames[i],
-                    color = fillColors[i],
-                    lineWidth = 10,
-                    markerShape = MarkerShape.none
-                };
-                legendItems.Add(item);
-            }
+			for (int i = 0; i < input.GetLength(0); i++)
+			{
+				for (int j = 0; j < input.GetLength(1); j++)
+				{
+					input[i, j] /= maxes[j];
+				}
+			}
 
-            return legendItems.ToArray();
-        }
+			return maxes;
+		}
 
-        public AxisLimits GetAxisLimits() => new AxisLimits(-2.5, 2.5, -2.5, 2.5);
+		public LegendItem[] GetLegendItems()
+		{
+			if (groupNames is null)
+				return null;
 
-        public int PointCount { get => normalized.Length; }
+			List<LegendItem> legendItems = new List<LegendItem>();
+			for (int i = 0; i < groupNames.Length; i++)
+			{
+				var item = new LegendItem()
+				{
+					label = groupNames[i],
+					color = fillColors[i],
+					lineWidth = 10,
+					markerShape = MarkerShape.none
+				};
+				legendItems.Add(item);
+			}
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-        {
-            int numGroups = normalized.GetUpperBound(0) + 1;
-            int numCategories = normalized.GetUpperBound(1) + 1;
-            double sweepAngle = 2 * Math.PI / numCategories;
-            double minScale = new double[] { dims.PxPerUnitX, dims.PxPerUnitX }.Min();
-            PointF origin = new PointF(dims.GetPixelX(0), dims.GetPixelY(0));
-            double[] radii = new double[] { 0.25 * minScale, 0.5 * minScale, 1 * minScale };
+			return legendItems.ToArray();
+		}
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-            using (Pen pen = GDI.Pen(webColor))
-            using (Brush brush = GDI.Brush(Color.Black))
-            using (StringFormat sf = new StringFormat() { LineAlignment = StringAlignment.Center })
-            using (System.Drawing.Font font = GDI.Font(Font))
-            using (Brush fontBrush = GDI.Brush(Font.Color))
-            {
-                for (int i = 0; i < radii.Length; i++)
-                {
-                    gfx.DrawEllipse(pen, (int)(origin.X - radii[i]), (int)(origin.Y - radii[i]), (int)(radii[i] * 2), (int)(radii[i] * 2));
-                    StringFormat stringFormat = new StringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Far };
-                    gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), stringFormat);
-                }
+		public AxisLimits GetAxisLimits() => new AxisLimits(-2.5, 2.5, -2.5, 2.5);
 
-                for (int i = 0; i < numCategories; i++)
-                {
-                    PointF destination = new PointF((float)(1.1 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X), (float)(1.1 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
-                    gfx.DrawLine(pen, origin, destination);
+		public int PointCount { get => normalized.Length; }
 
-                    if (categoryNames != null)
-                    {
-                        PointF textDestination = new PointF(
-                            (float)(1.3 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X),
-                            (float)(1.3 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
+		public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+		{
+			int numGroups = normalized.GetUpperBound(0) + 1;
+			int numCategories = normalized.GetUpperBound(1) + 1;
+			double sweepAngle = 2 * Math.PI / numCategories;
+			double minScale = new double[] { dims.PxPerUnitX, dims.PxPerUnitX }.Min();
+			PointF origin = new PointF(dims.GetPixelX(0), dims.GetPixelY(0));
+			double[] radii = new double[] { 0.25 * minScale, 0.5 * minScale, 1 * minScale };
 
-                        if (Math.Abs(textDestination.X - origin.X) < 0.1)
-                            sf.Alignment = StringAlignment.Center;
-                        else
-                            sf.Alignment = dims.GetCoordinateX(textDestination.X) < 0 ? StringAlignment.Far : StringAlignment.Near;
-                        gfx.DrawString(categoryNames[i], font, fontBrush, textDestination, sf);
-                    }
-                }
+			using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+			using (Pen pen = GDI.Pen(webColor))
+			using (Brush brush = GDI.Brush(Color.Black))
+			using (StringFormat sf = new StringFormat() { LineAlignment = StringAlignment.Center })
+			using (System.Drawing.Font font = GDI.Font(Font))
+			using (Brush fontBrush = GDI.Brush(Font.Color))
+			{
+				for (int i = 0; i < radii.Length; i++)
+				{
+					gfx.DrawEllipse(pen, (int)(origin.X - radii[i]), (int)(origin.Y - radii[i]), (int)(radii[i] * 2), (int)(radii[i] * 2));
+					using (StringFormat stringFormat = new StringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Far })
+					{
+						if (independentAxes)
+						{
+							for (int j = 0; j < numCategories; j++)
+							{
+								string text = $"{normalizedMaxes[j] * radii[i] / minScale:f1}";
 
-                for (int i = 0; i < numGroups; i++)
-                {
-                    PointF[] points = new PointF[numCategories];
-                    for (int j = 0; j < numCategories; j++)
-                        points[j] = new PointF(
-                            (float)(normalized[i, j] * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X),
-                            (float)(normalized[i, j] * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y));
+								double hypotenuse = (radii[i] / radii[radii.Length - 1]);
 
-                    ((SolidBrush)brush).Color = fillColors[i];
-                    pen.Color = lineColors[i];
-                    gfx.FillPolygon(brush, points);
-                    gfx.DrawPolygon(pen, points);
-                }
-            }
-        }
-    }
+								float x = (float)(hypotenuse * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X);
+								float y = (float)(hypotenuse * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y);
+
+								stringFormat.Alignment = x < origin.X ? StringAlignment.Far : StringAlignment.Near;
+								stringFormat.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
+
+								gfx.DrawString(text, font, fontBrush, x, y, stringFormat);
+							}
+						}
+						else
+						{
+							gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), stringFormat);
+						}
+					}
+				}
+
+				for (int i = 0; i < numCategories; i++)
+				{
+					PointF destination = new PointF((float)(1.1 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X), (float)(1.1 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
+					gfx.DrawLine(pen, origin, destination);
+
+					if (categoryNames != null)
+					{
+						PointF textDestination = new PointF(
+							(float)(1.3 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X),
+							(float)(1.3 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
+
+						if (Math.Abs(textDestination.X - origin.X) < 0.1)
+							sf.Alignment = StringAlignment.Center;
+						else
+							sf.Alignment = dims.GetCoordinateX(textDestination.X) < 0 ? StringAlignment.Far : StringAlignment.Near;
+						gfx.DrawString(categoryNames[i], font, fontBrush, textDestination, sf);
+					}
+				}
+
+				for (int i = 0; i < numGroups; i++)
+				{
+					PointF[] points = new PointF[numCategories];
+					for (int j = 0; j < numCategories; j++)
+						points[j] = new PointF(
+							(float)(normalized[i, j] * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X),
+							(float)(normalized[i, j] * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y));
+
+					((SolidBrush)brush).Color = fillColors[i];
+					pen.Color = lineColors[i];
+					gfx.FillPolygon(brush, points);
+					gfx.DrawPolygon(pen, points);
+				}
+			}
+		}
+	}
 }

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -6,216 +6,216 @@ using ScottPlot.Drawing;
 
 namespace ScottPlot.Plottable
 {
-	public class RadarPlot : IPlottable
-	{
-		private readonly double[,] normalized;
-		private readonly double normalizedMax;
-		private readonly double[] normalizedMaxes;
-		public string[] categoryNames;
-		public string[] groupNames;
-		public Color[] fillColors;
-		public Color[] lineColors;
-		public Color webColor;
-		public readonly bool independentAxes;
-		public bool IsVisible { get; set; } = true;
-		public int HorizontalAxisIndex { get; set; } = 0;
-		public int VerticalAxisIndex { get; set; } = 0;
-		public Drawing.Font Font = new Drawing.Font();
-		public bool showAxisLabels { get; set; } = true;
+    public class RadarPlot : IPlottable
+    {
+        private readonly double[,] normalized;
+        private readonly double normalizedMax;
+        private readonly double[] normalizedMaxes;
+        public string[] categoryNames;
+        public string[] groupNames;
+        public Color[] fillColors;
+        public Color[] lineColors;
+        public Color webColor;
+        public readonly bool independentAxes;
+        public bool IsVisible { get; set; } = true;
+        public int HorizontalAxisIndex { get; set; } = 0;
+        public int VerticalAxisIndex { get; set; } = 0;
+        public Drawing.Font Font = new Drawing.Font();
+        public bool showAxisLabels { get; set; } = true;
 
-		public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors, bool independentAxes)
-		{
-			this.lineColors = lineColors;
-			this.fillColors = fillColors;
-			this.independentAxes = independentAxes;
+        public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors, bool independentAxes)
+        {
+            this.lineColors = lineColors;
+            this.fillColors = fillColors;
+            this.independentAxes = independentAxes;
 
-			normalized = new double[values.GetLength(0), values.GetLength(1)];
-			Array.Copy(values, 0, normalized, 0, values.Length);
-			if (independentAxes)
-			{
-				normalizedMaxes = NormalizeSeveralInPlace(normalized);
-			}
-			else
-			{
-				normalizedMax = NormalizeInPlace(normalized);
-			}
-		}
+            normalized = new double[values.GetLength(0), values.GetLength(1)];
+            Array.Copy(values, 0, normalized, 0, values.Length);
+            if (independentAxes)
+            {
+                normalizedMaxes = NormalizeSeveralInPlace(normalized);
+            }
+            else
+            {
+                normalizedMax = NormalizeInPlace(normalized);
+            }
+        }
 
-		public override string ToString() =>
-			$"PlottableRadar with {PointCount} points and {normalized.GetUpperBound(1) + 1} categories.";
+        public override string ToString() =>
+            $"PlottableRadar with {PointCount} points and {normalized.GetUpperBound(1) + 1} categories.";
 
-		public void ValidateData(bool deep = false)
-		{
-			if (groupNames != null && groupNames.Length != normalized.GetLength(0))
-				throw new InvalidOperationException("group names must match size of values");
+        public void ValidateData(bool deep = false)
+        {
+            if (groupNames != null && groupNames.Length != normalized.GetLength(0))
+                throw new InvalidOperationException("group names must match size of values");
 
-			if (categoryNames != null && categoryNames.Length != normalized.GetLength(1))
-				throw new InvalidOperationException("category names must match size of values");
-		}
+            if (categoryNames != null && categoryNames.Length != normalized.GetLength(1))
+                throw new InvalidOperationException("category names must match size of values");
+        }
 
-		/// <summary>
-		/// Normalize a 2D array by dividing all values by the maximum value.
-		/// </summary>
-		/// <returns>maximum value in the array before normalization</returns>
-		private double NormalizeInPlace(double[,] input)
-		{
-			double max = input[0, 0];
+        /// <summary>
+        /// Normalize a 2D array by dividing all values by the maximum value.
+        /// </summary>
+        /// <returns>maximum value in the array before normalization</returns>
+        private double NormalizeInPlace(double[,] input)
+        {
+            double max = input[0, 0];
 
-			for (int i = 0; i < input.GetLength(0); i++)
-				for (int j = 0; j < input.GetLength(1); j++)
-					max = Math.Max(max, input[i, j]);
+            for (int i = 0; i < input.GetLength(0); i++)
+                for (int j = 0; j < input.GetLength(1); j++)
+                    max = Math.Max(max, input[i, j]);
 
-			for (int i = 0; i < input.GetLength(0); i++)
-				for (int j = 0; j < input.GetLength(1); j++)
-					input[i, j] /= max;
+            for (int i = 0; i < input.GetLength(0); i++)
+                for (int j = 0; j < input.GetLength(1); j++)
+                    input[i, j] /= max;
 
-			return max;
-		}
+            return max;
+        }
 
-		/// <summary>
-		/// Normalize each row of a 2D array independently by dividing all values by the maximum value.
-		/// </summary>
-		/// <returns>maximum value in each row of the array before normalization</returns>
-		private double[] NormalizeSeveralInPlace(double[,] input)
-		{
-			double[] maxes = new double[input.GetLength(1)];
-			for (int i = 0; i < input.GetLength(1); i++)
-			{
-				double max = input[0, i];
-				for (int j = 0; j < input.GetLength(0); j++)
-				{
-					max = Math.Max(input[j, i], max);
-				}
-				maxes[i] = max;
-			}
+        /// <summary>
+        /// Normalize each row of a 2D array independently by dividing all values by the maximum value.
+        /// </summary>
+        /// <returns>maximum value in each row of the array before normalization</returns>
+        private double[] NormalizeSeveralInPlace(double[,] input)
+        {
+            double[] maxes = new double[input.GetLength(1)];
+            for (int i = 0; i < input.GetLength(1); i++)
+            {
+                double max = input[0, i];
+                for (int j = 0; j < input.GetLength(0); j++)
+                {
+                    max = Math.Max(input[j, i], max);
+                }
+                maxes[i] = max;
+            }
 
-			for (int i = 0; i < input.GetLength(0); i++)
-			{
-				for (int j = 0; j < input.GetLength(1); j++)
-				{
-					input[i, j] /= maxes[j];
-				}
-			}
+            for (int i = 0; i < input.GetLength(0); i++)
+            {
+                for (int j = 0; j < input.GetLength(1); j++)
+                {
+                    input[i, j] /= maxes[j];
+                }
+            }
 
-			return maxes;
-		}
+            return maxes;
+        }
 
-		public LegendItem[] GetLegendItems()
-		{
-			if (groupNames is null)
-				return null;
+        public LegendItem[] GetLegendItems()
+        {
+            if (groupNames is null)
+                return null;
 
-			List<LegendItem> legendItems = new List<LegendItem>();
-			for (int i = 0; i < groupNames.Length; i++)
-			{
-				var item = new LegendItem()
-				{
-					label = groupNames[i],
-					color = fillColors[i],
-					lineWidth = 10,
-					markerShape = MarkerShape.none
-				};
-				legendItems.Add(item);
-			}
+            List<LegendItem> legendItems = new List<LegendItem>();
+            for (int i = 0; i < groupNames.Length; i++)
+            {
+                var item = new LegendItem()
+                {
+                    label = groupNames[i],
+                    color = fillColors[i],
+                    lineWidth = 10,
+                    markerShape = MarkerShape.none
+                };
+                legendItems.Add(item);
+            }
 
-			return legendItems.ToArray();
-		}
+            return legendItems.ToArray();
+        }
 
-		public AxisLimits GetAxisLimits()
-		{
-			if (groupNames != null)
-			{
-				return new AxisLimits(-3.5, 3.5, -3.5, 3.5);
-			}
-			else
-			{
-				return new AxisLimits(-2.5, 2.5, -2.5, 2.5);
-			}
-		}
+        public AxisLimits GetAxisLimits()
+        {
+            if (groupNames != null)
+            {
+                return new AxisLimits(-3.5, 3.5, -3.5, 3.5);
+            }
+            else
+            {
+                return new AxisLimits(-2.5, 2.5, -2.5, 2.5);
+            }
+        }
 
-		public int PointCount { get => normalized.Length; }
+        public int PointCount { get => normalized.Length; }
 
-		public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-		{
-			int numGroups = normalized.GetUpperBound(0) + 1;
-			int numCategories = normalized.GetUpperBound(1) + 1;
-			double sweepAngle = 2 * Math.PI / numCategories;
-			double minScale = new double[] { dims.PxPerUnitX, dims.PxPerUnitX }.Min();
-			PointF origin = new PointF(dims.GetPixelX(0), dims.GetPixelY(0));
-			double[] radii = new double[] { 0.25 * minScale, 0.5 * minScale, 1 * minScale };
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            int numGroups = normalized.GetUpperBound(0) + 1;
+            int numCategories = normalized.GetUpperBound(1) + 1;
+            double sweepAngle = 2 * Math.PI / numCategories;
+            double minScale = new double[] { dims.PxPerUnitX, dims.PxPerUnitX }.Min();
+            PointF origin = new PointF(dims.GetPixelX(0), dims.GetPixelY(0));
+            double[] radii = new double[] { 0.25 * minScale, 0.5 * minScale, 1 * minScale };
 
-			using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-			using (Pen pen = GDI.Pen(webColor))
-			using (Brush brush = GDI.Brush(Color.Black))
-			using (StringFormat sf = new StringFormat() { LineAlignment = StringAlignment.Center })
-			using (System.Drawing.Font font = GDI.Font(Font))
-			using (Brush fontBrush = GDI.Brush(Font.Color))
-			{
-				for (int i = 0; i < radii.Length; i++)
-				{
-					gfx.DrawEllipse(pen, (int)(origin.X - radii[i]), (int)(origin.Y - radii[i]), (int)(radii[i] * 2), (int)(radii[i] * 2));
-					if (showAxisLabels)
-					{
-						using (StringFormat stringFormat = new StringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Far })
-						{
-							if (independentAxes)
-							{
-								for (int j = 0; j < numCategories; j++)
-								{
-									string text = $"{normalizedMaxes[j] * radii[i] / minScale:f1}";
+            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            using (Pen pen = GDI.Pen(webColor))
+            using (Brush brush = GDI.Brush(Color.Black))
+            using (StringFormat sf = new StringFormat() { LineAlignment = StringAlignment.Center })
+            using (System.Drawing.Font font = GDI.Font(Font))
+            using (Brush fontBrush = GDI.Brush(Font.Color))
+            {
+                for (int i = 0; i < radii.Length; i++)
+                {
+                    gfx.DrawEllipse(pen, (int)(origin.X - radii[i]), (int)(origin.Y - radii[i]), (int)(radii[i] * 2), (int)(radii[i] * 2));
+                    if (showAxisLabels)
+                    {
+                        using (StringFormat stringFormat = new StringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Far })
+                        {
+                            if (independentAxes)
+                            {
+                                for (int j = 0; j < numCategories; j++)
+                                {
+                                    string text = $"{normalizedMaxes[j] * radii[i] / minScale:f1}";
 
-									double hypotenuse = (radii[i] / radii[radii.Length - 1]);
+                                    double hypotenuse = (radii[i] / radii[radii.Length - 1]);
 
-									float x = (float)(hypotenuse * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X);
-									float y = (float)(hypotenuse * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y);
+                                    float x = (float)(hypotenuse * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X);
+                                    float y = (float)(hypotenuse * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y);
 
-									stringFormat.Alignment = x < origin.X ? StringAlignment.Far : StringAlignment.Near;
-									stringFormat.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
+                                    stringFormat.Alignment = x < origin.X ? StringAlignment.Far : StringAlignment.Near;
+                                    stringFormat.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
 
-									gfx.DrawString(text, font, fontBrush, x, y, stringFormat);
-								}
-							}
-							else
-							{
-								gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), stringFormat);
-							}
-						}
-					}
-				}
+                                    gfx.DrawString(text, font, fontBrush, x, y, stringFormat);
+                                }
+                            }
+                            else
+                            {
+                                gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), stringFormat);
+                            }
+                        }
+                    }
+                }
 
-				for (int i = 0; i < numCategories; i++)
-				{
-					PointF destination = new PointF((float)(1.1 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X), (float)(1.1 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
-					gfx.DrawLine(pen, origin, destination);
+                for (int i = 0; i < numCategories; i++)
+                {
+                    PointF destination = new PointF((float)(1.1 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X), (float)(1.1 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
+                    gfx.DrawLine(pen, origin, destination);
 
-					if (categoryNames != null)
-					{
-						PointF textDestination = new PointF(
-							(float)(1.3 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X),
-							(float)(1.3 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
+                    if (categoryNames != null)
+                    {
+                        PointF textDestination = new PointF(
+                            (float)(1.3 * Math.Cos(sweepAngle * i - Math.PI / 2) * minScale + origin.X),
+                            (float)(1.3 * Math.Sin(sweepAngle * i - Math.PI / 2) * minScale + origin.Y));
 
-						if (Math.Abs(textDestination.X - origin.X) < 0.1)
-							sf.Alignment = StringAlignment.Center;
-						else
-							sf.Alignment = dims.GetCoordinateX(textDestination.X) < 0 ? StringAlignment.Far : StringAlignment.Near;
-						gfx.DrawString(categoryNames[i], font, fontBrush, textDestination, sf);
-					}
-				}
+                        if (Math.Abs(textDestination.X - origin.X) < 0.1)
+                            sf.Alignment = StringAlignment.Center;
+                        else
+                            sf.Alignment = dims.GetCoordinateX(textDestination.X) < 0 ? StringAlignment.Far : StringAlignment.Near;
+                        gfx.DrawString(categoryNames[i], font, fontBrush, textDestination, sf);
+                    }
+                }
 
-				for (int i = 0; i < numGroups; i++)
-				{
-					PointF[] points = new PointF[numCategories];
-					for (int j = 0; j < numCategories; j++)
-						points[j] = new PointF(
-							(float)(normalized[i, j] * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X),
-							(float)(normalized[i, j] * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y));
+                for (int i = 0; i < numGroups; i++)
+                {
+                    PointF[] points = new PointF[numCategories];
+                    for (int j = 0; j < numCategories; j++)
+                        points[j] = new PointF(
+                            (float)(normalized[i, j] * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X),
+                            (float)(normalized[i, j] * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y));
 
-					((SolidBrush)brush).Color = fillColors[i];
-					pen.Color = lineColors[i];
-					gfx.FillPolygon(brush, points);
-					gfx.DrawPolygon(pen, points);
-				}
-			}
-		}
-	}
+                    ((SolidBrush)brush).Color = fillColors[i];
+                    pen.Color = lineColors[i];
+                    gfx.FillPolygon(brush, points);
+                    gfx.DrawPolygon(pen, points);
+                }
+            }
+        }
+    }
 }

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -21,6 +21,7 @@ namespace ScottPlot.Plottable
 		public int HorizontalAxisIndex { get; set; } = 0;
 		public int VerticalAxisIndex { get; set; } = 0;
 		public Drawing.Font Font = new Drawing.Font();
+		public bool showAxisLabels { get; set; } = true;
 
 		public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors, bool independentAxes)
 		{
@@ -143,28 +144,31 @@ namespace ScottPlot.Plottable
 				for (int i = 0; i < radii.Length; i++)
 				{
 					gfx.DrawEllipse(pen, (int)(origin.X - radii[i]), (int)(origin.Y - radii[i]), (int)(radii[i] * 2), (int)(radii[i] * 2));
-					using (StringFormat stringFormat = new StringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Far })
+					if (showAxisLabels)
 					{
-						if (independentAxes)
+						using (StringFormat stringFormat = new StringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Far })
 						{
-							for (int j = 0; j < numCategories; j++)
+							if (independentAxes)
 							{
-								string text = $"{normalizedMaxes[j] * radii[i] / minScale:f1}";
+								for (int j = 0; j < numCategories; j++)
+								{
+									string text = $"{normalizedMaxes[j] * radii[i] / minScale:f1}";
 
-								double hypotenuse = (radii[i] / radii[radii.Length - 1]);
+									double hypotenuse = (radii[i] / radii[radii.Length - 1]);
 
-								float x = (float)(hypotenuse * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X);
-								float y = (float)(hypotenuse * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y);
+									float x = (float)(hypotenuse * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X);
+									float y = (float)(hypotenuse * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y);
 
-								stringFormat.Alignment = x < origin.X ? StringAlignment.Far : StringAlignment.Near;
-								stringFormat.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
+									stringFormat.Alignment = x < origin.X ? StringAlignment.Far : StringAlignment.Near;
+									stringFormat.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
 
-								gfx.DrawString(text, font, fontBrush, x, y, stringFormat);
+									gfx.DrawString(text, font, fontBrush, x, y, stringFormat);
+								}
 							}
-						}
-						else
-						{
-							gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), stringFormat);
+							else
+							{
+								gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), stringFormat);
+							}
 						}
 					}
 				}

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -148,6 +148,7 @@ namespace ScottPlot.Plottable
             using (Pen pen = GDI.Pen(webColor))
             using (Brush brush = GDI.Brush(Color.Black))
             using (StringFormat sf = new StringFormat() { LineAlignment = StringAlignment.Center })
+            using (StringFormat sf2 = new StringFormat())
             using (System.Drawing.Font font = GDI.Font(Font))
             using (Brush fontBrush = GDI.Brush(Font.Color))
             {
@@ -156,7 +157,6 @@ namespace ScottPlot.Plottable
                     gfx.DrawEllipse(pen, (int)(origin.X - radii[i]), (int)(origin.Y - radii[i]), (int)(radii[i] * 2), (int)(radii[i] * 2));
                     if (showAxisLabels)
                     {
-                        using (StringFormat stringFormat = new StringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Far })
                         {
                             if (independentAxes)
                             {
@@ -169,15 +169,15 @@ namespace ScottPlot.Plottable
                                     float x = (float)(hypotenuse * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X);
                                     float y = (float)(hypotenuse * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y);
 
-                                    stringFormat.Alignment = x < origin.X ? StringAlignment.Far : StringAlignment.Near;
-                                    stringFormat.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
+                                    sf2.Alignment = x < origin.X ? StringAlignment.Far : StringAlignment.Near;
+                                    sf2.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
 
-                                    gfx.DrawString(text, font, fontBrush, x, y, stringFormat);
+                                    gfx.DrawString(text, font, fontBrush, x, y, sf2);
                                 }
                             }
                             else
                             {
-                                gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), stringFormat);
+                                gfx.DrawString($"{normalizedMax * radii[i] / minScale:f1}", font, fontBrush, origin.X, (float)(-radii[i] + origin.Y), sf2);
                             }
                         }
                     }

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -121,7 +121,17 @@ namespace ScottPlot.Plottable
 			return legendItems.ToArray();
 		}
 
-		public AxisLimits GetAxisLimits() => new AxisLimits(-2.5, 2.5, -2.5, 2.5);
+		public AxisLimits GetAxisLimits()
+		{
+			if (groupNames != null)
+			{
+				return new AxisLimits(-3.5, 3.5, -3.5, 3.5);
+			}
+			else
+			{
+				return new AxisLimits(-2.5, 2.5, -2.5, 2.5);
+			}
+		}
 
 		public int PointCount { get => normalized.Length; }
 

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -121,17 +121,8 @@ namespace ScottPlot.Plottable
             return legendItems.ToArray();
         }
 
-        public AxisLimits GetAxisLimits()
-        {
-            if (groupNames != null)
-            {
-                return new AxisLimits(-3.5, 3.5, -3.5, 3.5);
-            }
-            else
-            {
-                return new AxisLimits(-2.5, 2.5, -2.5, 2.5);
-            }
-        }
+        public AxisLimits GetAxisLimits() =>
+            (groupNames != null) ? new AxisLimits(-3.5, 3.5, -3.5, 3.5) : new AxisLimits(-2.5, 2.5, -2.5, 2.5);
 
         public int PointCount { get => normalized.Length; }
 

--- a/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
+++ b/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
@@ -82,5 +82,34 @@ namespace ScottPlot.Demo.PlotTypes
                  */
             }
         }
+
+        public class RadarUnlabeledAxes : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Radar With Unlabeled Axes";
+            public string description { get; } = "Radar charts support unlabeled axes.";
+
+            public void Render(Plot plt)
+            {
+                double[,] values = { { 5, 3, 10, 15, 3, 2, 256 }, { 5, 2, 10, 10, 1, 4, 252 }, };
+                string[] categories = { "Wins", "Poles", "Podiums", "Points Finishes", "DNFs", "Fastest Laps", "Points" };
+                string[] groups = { "Sebastian Vettel", "Fernando Alonso" };
+
+                var radarPlot = plt.PlotRadar(values, categories, groups, independentAxes: true);
+                radarPlot.showAxisLabels = false;
+                plt.Legend();
+
+                // customize the plot
+                plt.Grid(false);
+                plt.Frame(false);
+                plt.Ticks(false, false);
+                plt.Title("2010 Formula One World Championship");
+
+                /* Data represents the 2010 Formula One World Championship
+                 * https://en.wikipedia.org/wiki/2010_Formula_One_World_Championship
+                 * Note: Alonso did not finish (DNF) in the Malaysian GP, but was included 
+                 * here because he completed >90% of the race distance.
+                 */
+            }
+        }
     }
 }

--- a/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
+++ b/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
@@ -62,7 +62,7 @@ namespace ScottPlot.Demo.PlotTypes
 
             public void Render(Plot plt)
             {
-                double[,] values = { { 5, 3, 10, 15, 3, 2,  256}, { 5, 2, 10, 10, 1, 4, 252 }, };
+                double[,] values = { { 5, 3, 10, 15, 3, 2, 256 }, { 5, 2, 10, 10, 1, 4, 252 }, };
                 string[] categories = { "Wins", "Poles", "Podiums", "Points Finishes", "DNFs", "Fastest Laps", "Points" };
                 string[] groups = { "Sebastian Vettel", "Fernando Alonso" };
 

--- a/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
+++ b/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
@@ -54,5 +54,33 @@ namespace ScottPlot.Demo.PlotTypes
                  */
             }
         }
+
+        public class RadarSeveralAxes : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Radar With Multiple Axes";
+            public string description { get; } = "Radar charts support multiple axes.";
+
+            public void Render(Plot plt)
+            {
+                double[,] values = { { 5, 3, 10, 15, 3, 2,  256}, { 5, 2, 10, 10, 1, 4, 252 }, };
+                string[] categories = { "Wins", "Poles", "Podiums", "Points Finishes", "DNFs", "Fastest Laps", "Points" };
+                string[] groups = { "Sebastian Vettel", "Fernando Alonso" };
+
+                plt.PlotRadar(values, categories, groups, independentAxes: true);
+                plt.Legend();
+
+                // customize the plot
+                plt.Grid(false);
+                plt.Frame(false);
+                plt.Ticks(false, false);
+                plt.Title("2010 Formula One World Championship");
+
+                /* Data represents the 2010 Formula One World Championship
+                 * https://en.wikipedia.org/wiki/2010_Formula_One_World_Championship
+                 * Note: Alonso did not finish (DNF) in the Malaysian GP, but was included 
+                 * here because he completed >90% of the race distance.
+                 */
+            }
+        }
     }
 }


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#628 

**New Functionality:**
Adds two options, a parameter `bool independentAxes` which determines whether the axes should be separate. And a public property `bool showAxisLabels` which determines whether axis labels are shown.

The following demo shows both:
```cs
double[,] values = { { 5, 3, 10, 15, 3, 2, 256 }, { 5, 2, 10, 10, 1, 4, 252 }, };
string[] categories = { "Wins", "Poles", "Podiums", "Points Finishes", "DNFs", "Fastest Laps", "Points" };
string[] groups = { "Sebastian Vettel", "Fernando Alonso" };

var radarPlot = plt.PlotRadar(values, categories, groups, independentAxes: true);
radarPlot.showAxisLabels = false;
plt.Legend();

// customize the plot
plt.Grid(false);
plt.Frame(false);
plt.Ticks(false, false);
plt.Title("2010 Formula One World Championship");

/* Data represents the 2010 Formula One World Championship
 * https://en.wikipedia.org/wiki/2010_Formula_One_World_Championship
 * Note: Alonso did not finish (DNF) in the Malaysian GP, but was included 
 * here because he completed >90% of the race distance.
 */
```

Labeled:
![image](https://user-images.githubusercontent.com/8635304/100527998-0a710800-3195-11eb-9c08-0ec54c15a803.png)

Unlabeled:
![image](https://user-images.githubusercontent.com/8635304/100527999-11981600-3195-11eb-9290-dc812dda6f1f.png)

As you might expect, the graph is rather cluttered with all the axis labels turned on.

**Other Notes**
The axis limits for radar plots were adjusted in 2d4f388e3937042805b82995a30713ff12ab801c to make it look nicer.

I accidentally created this when changing stuff, and I actually thought it looked cool:
![image](https://user-images.githubusercontent.com/8635304/100528037-76ec0700-3195-11eb-9997-9a40dca18cf5.png)
Makes me wonder if there should be an option to remove the circular rings? Or replace them with polygonal ones, like in this one, for example: 
![image](https://user-images.githubusercontent.com/8635304/100528062-a8fd6900-3195-11eb-97e3-2e164f848a5b.png)
