### PR TITLE
Radar with pre-defined max values

### DIFF
--- a/src/ScottPlot/Plot/Plot.PlotMisc.cs
+++ b/src/ScottPlot/Plot/Plot.PlotMisc.cs
@@ -66,13 +66,14 @@ namespace ScottPlot
             Color[] fillColors = null,
             double fillAlpha = .4,
             Color? webColor = null,
-            bool independentAxes = false
+            bool independentAxes = false,
+            double[] maxValues = null
             )
         {
             Color[] colors = fillColors ?? Enumerable.Range(0, values.Length).Select(i => settings.PlottablePalette.GetColor(i)).ToArray();
             Color[] colorsAlpha = colors.Select(x => Color.FromArgb((byte)(255 * fillAlpha), x)).ToArray();
 
-            var plottable = new RadarPlot(values, colors, fillColors ?? colorsAlpha, independentAxes)
+            var plottable = new RadarPlot(values, colors, fillColors ?? colorsAlpha, independentAxes, maxValues)
             {
                 categoryNames = categoryNames,
                 groupNames = groupNames,

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -24,7 +24,7 @@ namespace ScottPlot.Plottable
         public bool showAxisLabels { get; set; } = true;
         public RadarAxis axisType { get; set; } = RadarAxis.Circle;
 
-        public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors, bool independentAxes)
+        public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors, bool independentAxes, double[] maxValues = null)
         {
             this.lineColors = lineColors;
             this.fillColors = fillColors;
@@ -34,11 +34,11 @@ namespace ScottPlot.Plottable
             Array.Copy(values, 0, normalized, 0, values.Length);
             if (independentAxes)
             {
-                normalizedMaxes = NormalizeSeveralInPlace(normalized);
+                normalizedMaxes = NormalizeSeveralInPlace(normalized, maxValues);
             }
             else
             {
-                normalizedMax = NormalizeInPlace(normalized);
+                normalizedMax = NormalizeInPlace(normalized, maxValues);
             }
         }
 
@@ -58,13 +58,20 @@ namespace ScottPlot.Plottable
         /// Normalize a 2D array by dividing all values by the maximum value.
         /// </summary>
         /// <returns>maximum value in the array before normalization</returns>
-        private double NormalizeInPlace(double[,] input)
+        private double NormalizeInPlace(double[,] input, double[] maxValues = null)
         {
-            double max = input[0, 0];
-
-            for (int i = 0; i < input.GetLength(0); i++)
-                for (int j = 0; j < input.GetLength(1); j++)
-                    max = Math.Max(max, input[i, j]);
+            double max;
+            if (maxValues != null && maxValues.Length == 1)
+            {
+                max = maxValues[0];
+            }
+            else
+            {
+                max = input[0, 0];
+                for (int i = 0; i < input.GetLength(0); i++)
+                    for (int j = 0; j < input.GetLength(1); j++)
+                        max = Math.Max(max, input[i, j]);
+            }
 
             for (int i = 0; i < input.GetLength(0); i++)
                 for (int j = 0; j < input.GetLength(1); j++)
@@ -77,17 +84,25 @@ namespace ScottPlot.Plottable
         /// Normalize each row of a 2D array independently by dividing all values by the maximum value.
         /// </summary>
         /// <returns>maximum value in each row of the array before normalization</returns>
-        private double[] NormalizeSeveralInPlace(double[,] input)
+        private double[] NormalizeSeveralInPlace(double[,] input, double[] maxValues = null)
         {
-            double[] maxes = new double[input.GetLength(1)];
-            for (int i = 0; i < input.GetLength(1); i++)
+            double[] maxes;
+            if (maxValues != null && input.GetLength(1) == maxValues.Length)
             {
-                double max = input[0, i];
-                for (int j = 0; j < input.GetLength(0); j++)
+                maxes = maxValues;
+            }
+            else
+            {
+                maxes = new double[input.GetLength(1)];
+                for (int i = 0; i < input.GetLength(1); i++)
                 {
-                    max = Math.Max(input[j, i], max);
+                    double max = input[0, i];
+                    for (int j = 0; j < input.GetLength(0); j++)
+                    {
+                        max = Math.Max(input[j, i], max);
+                    }
+                    maxes[i] = max;
                 }
-                maxes[i] = max;
             }
 
             for (int i = 0; i < input.GetLength(0); i++)

--- a/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
+++ b/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
@@ -127,7 +127,7 @@ namespace ScottPlot.Demo.PlotTypes
                  */
             }
         }
-        
+
         public class RadarSeveralAxesWithMax : PlotDemo, IPlotDemo
         {
             public string name { get; } = "Radar With Multiple Axes And Pre-Defined Max Values";

--- a/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
+++ b/src/cookbook/ScottPlot.Demo/PlotTypes/Radar.cs
@@ -127,6 +127,37 @@ namespace ScottPlot.Demo.PlotTypes
                  */
             }
         }
+        
+        public class RadarSeveralAxesWithMax : PlotDemo, IPlotDemo
+        {
+            public string name { get; } = "Radar With Multiple Axes And Pre-Defined Max Values";
+            public string description { get; } = "Radar charts support multiple axes with pre-defined max. values.";
+
+            public void Render(Plot plt)
+            {
+                double[,] values = { { 5, 3, 10, 15, 3, 2, 256 }, { 5, 2, 10, 10, 1, 4, 252 }, };
+                double[] maxValues = { 13, 15, 17, 15, 10, 10, 413 };
+                string[] categories = { "Wins", "Poles", "Podiums", "Points Finishes", "DNFs", "Fastest Laps", "Points" };
+                string[] groups = { "Sebastian Vettel", "Fernando Alonso" };
+
+                plt.PlotRadar(values, categories, groups, independentAxes: true, maxValues: maxValues);
+                plt.Legend();
+
+                // customize the plot
+                plt.Grid(false);
+                plt.Frame(false);
+                plt.Ticks(false, false);
+                plt.Title("2010 Formula One World Championship");
+
+                /* Data represents the 2010 Formula One World Championship
+                 * https://en.wikipedia.org/wiki/2010_Formula_One_World_Championship
+                 * Note: Alonso did not finish (DNF) in the Malaysian GP, but was included 
+                 * here because he completed >90% of the race distance.
+                 *
+                 * Max values are based on https://en.wikipedia.org/wiki/List_of_Formula_One_World_Drivers%27_Champions.
+                 */
+            }
+        }
 
         public class RadarUnlabeledAxes : PlotDemo, IPlotDemo
         {


### PR DESCRIPTION
**Purpose:**
cf. #628

**New Functionality:**
Added the option to pre-define the max values, independent of the provided values to plot.

```cs
double[,] values = { { 5, 3, 10, 15, 3, 2, 256 }, { 5, 2, 10, 10, 1, 4, 252 }, };
double[] maxValues = { 13, 15, 17, 15, 10, 10, 413 };
string[] categories = { "Wins", "Poles", "Podiums", "Points Finishes", "DNFs", "Fastest Laps", "Points" };
string[] groups = { "Sebastian Vettel", "Fernando Alonso" };

plt.PlotRadar(values, categories, groups, independentAxes: true, maxValues: maxValues);
plt.Legend();

// customize the plot
plt.Grid(false);
plt.Frame(false);
plt.Ticks(false, false);
plt.Title("2010 Formula One World Championship");

/* Data represents the 2010 Formula One World Championship
 * https://en.wikipedia.org/wiki/2010_Formula_One_World_Championship
 * Note: Alonso did not finish (DNF) in the Malaysian GP, but was included 
 * here because he completed >90% of the race distance.
 *
 * Max values are based on https://en.wikipedia.org/wiki/List_of_Formula_One_World_Drivers%27_Champions.
 */
```