### PR TITLE
Fix some resource leaks (CPU and mem) when using Live Data forms

### DIFF
--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataFixed.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataFixed.axaml.cs
@@ -17,6 +17,9 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
         DataGen.Electrocardiogram ecg = new DataGen.Electrocardiogram();
         Stopwatch sw = Stopwatch.StartNew();
 
+        private Timer _updateDataTimer;
+        private DispatcherTimer _renderTimer;
+
         public LiveDataFixed()
         {
             this.InitializeComponent();
@@ -33,23 +36,25 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             avaPlot1.plt.SetAxisLimits(yMin: -1, yMax: 2.5);
 
             // create a traditional timer to update the data
-            _timer = new Timer(_ => UpdateData(), null, 0, 5);
+            _updateDataTimer = new Timer(_ => UpdateData(), null, 0, 5);
 
             // create a separate timer to update the GUI
-            DispatcherTimer renderTimer = new DispatcherTimer();
-            renderTimer.Interval = TimeSpan.FromMilliseconds(10);
-            renderTimer.Tick += Render;
-            renderTimer.Start();
+            _renderTimer = new DispatcherTimer();
+            _renderTimer.Interval = TimeSpan.FromMilliseconds(10);
+            _renderTimer.Tick += Render;
+            _renderTimer.Start();
 
+            Closed += (sender, args) =>
+            {
+                _updateDataTimer?.Dispose();
+                _renderTimer?.Stop();
+            };
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
         }
-
-
-        private System.Threading.Timer _timer;
 
         void UpdateData()
         {

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataGrowing.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataGrowing.axaml.cs
@@ -20,6 +20,9 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
         TextBox LatestValueTextbox;
         CheckBox AutoAxisCheckbox;
 
+        private DispatcherTimer _updateDataTimer;
+        private DispatcherTimer _renderTimer;
+
         public LiveDataGrowing()
         {
             this.InitializeComponent();
@@ -38,16 +41,22 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             avaPlot1.plt.XLabel("Sample Number");
 
             // create a timer to modify the data
-            DispatcherTimer updateDataTimer = new DispatcherTimer();
-            updateDataTimer.Interval = TimeSpan.FromMilliseconds(1);
-            updateDataTimer.Tick += UpdateData;
-            updateDataTimer.Start();
+            _updateDataTimer = new DispatcherTimer();
+            _updateDataTimer.Interval = TimeSpan.FromMilliseconds(1);
+            _updateDataTimer.Tick += UpdateData;
+            _updateDataTimer.Start();
 
             // create a timer to update the GUI
-            DispatcherTimer renderTimer = new DispatcherTimer();
-            renderTimer.Interval = TimeSpan.FromMilliseconds(20);
-            renderTimer.Tick += Render;
-            renderTimer.Start();
+            _renderTimer = new DispatcherTimer();
+            _renderTimer.Interval = TimeSpan.FromMilliseconds(20);
+            _renderTimer.Tick += Render;
+            _renderTimer.Start();
+
+            Closed += (sender, args) =>
+            {
+                _updateDataTimer?.Stop();
+                _renderTimer?.Stop();
+            };
         }
 
         private void InitializeComponent()

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataFixed.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataFixed.xaml.cs
@@ -25,7 +25,8 @@ namespace ScottPlot.Demo.WPF.WpfDemos
         DataGen.Electrocardiogram ecg = new DataGen.Electrocardiogram();
         Stopwatch sw = Stopwatch.StartNew();
 
-        private System.Threading.Timer _timer;
+        private Timer _updateDataTimer;
+        private DispatcherTimer _renderTimer;
 
         public LiveDataFixed()
         {
@@ -38,13 +39,19 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             wpfPlot1.plt.SetAxisLimits(yMin: -1, yMax: 2.5);
 
             // create a traditional timer to update the data
-            _timer = new Timer(_ => UpdateData(), null, 0, 5);
+            _updateDataTimer = new Timer(_ => UpdateData(), null, 0, 5);
 
             // create a separate timer to update the GUI
-            DispatcherTimer renderTimer = new DispatcherTimer();
-            renderTimer.Interval = TimeSpan.FromMilliseconds(10);
-            renderTimer.Tick += Render;
-            renderTimer.Start();
+            _renderTimer = new DispatcherTimer();
+            _renderTimer.Interval = TimeSpan.FromMilliseconds(10);
+            _renderTimer.Tick += Render;
+            _renderTimer.Start();
+
+            Closed += (sender, args) =>
+            {
+                _updateDataTimer?.Dispose();
+                _renderTimer?.Stop();
+            };
         }
 
         void UpdateData()

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataGrowing.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataGrowing.xaml.cs
@@ -24,6 +24,9 @@ namespace ScottPlot.Demo.WPF.WpfDemos
         SignalPlot signalPlot;
         Random rand = new Random(0);
 
+        private DispatcherTimer _updateDataTimer;
+        private DispatcherTimer _renderTimer;
+
         public LiveDataGrowing()
         {
             InitializeComponent();
@@ -34,16 +37,22 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             wpfPlot1.plt.XLabel("Sample Number");
 
             // create a timer to modify the data
-            DispatcherTimer updateDataTimer = new DispatcherTimer();
-            updateDataTimer.Interval = TimeSpan.FromMilliseconds(1);
-            updateDataTimer.Tick += UpdateData;
-            updateDataTimer.Start();
+            _updateDataTimer = new DispatcherTimer();
+            _updateDataTimer.Interval = TimeSpan.FromMilliseconds(1);
+            _updateDataTimer.Tick += UpdateData;
+            _updateDataTimer.Start();
 
             // create a timer to update the GUI
-            DispatcherTimer renderTimer = new DispatcherTimer();
-            renderTimer.Interval = TimeSpan.FromMilliseconds(20);
-            renderTimer.Tick += Render;
-            renderTimer.Start();
+            _renderTimer = new DispatcherTimer();
+            _renderTimer.Interval = TimeSpan.FromMilliseconds(20);
+            _renderTimer.Tick += Render;
+            _renderTimer.Start();
+
+            Closed += (sender, args) =>
+            {
+                _updateDataTimer?.Stop();
+                _renderTimer?.Stop();
+            };
         }
 
         void UpdateData(object sender, EventArgs e)

--- a/src/demo/ScottPlot.Demo.WinForms/FormMain.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/FormMain.cs
@@ -54,12 +54,16 @@ namespace ScottPlot.Demo.WinForms
 
         private void LiveData_Click(object sender, EventArgs e)
         {
-            new WinFormsDemos.LiveDataUpdate().ShowDialog();
+            var liveDataUpdate = new WinFormsDemos.LiveDataUpdate();
+            liveDataUpdate.ShowDialog();
+            liveDataUpdate.Dispose();
         }
 
         private void GrowingData_Click(object sender, EventArgs e)
         {
-            new WinFormsDemos.LiveDataIncoming().ShowDialog();
+            var liveDataIncoming = new WinFormsDemos.LiveDataIncoming();
+            liveDataIncoming.ShowDialog();
+            liveDataIncoming.Dispose();
         }
 
         private void btnShowOnHover_Click(object sender, EventArgs e)


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#649

For WPF and Avalonia:

I used the `Closed` event to stop the timers. This fixes the issue.

For WinForms:

Timers are linked to the window, which is exactly what we want. The only problem is that we did not call `Dispose` on the form after it was closed. By calling dispose on the form, it will take care of its timers.

Note: I did not know if you wanted me to target master or this branch. If it was master, you could just cherry-pick the commit.