### PR TITLE
Fix AxisSpan disapear on extreme zoom in

### DIFF
--- a/src/ScottPlot/Plottable/AxisSpan.cs
+++ b/src/ScottPlot/Plottable/AxisSpan.cs
@@ -1,5 +1,5 @@
-﻿using ScottPlot.Ticks;
-using ScottPlot.Drawing;
+﻿using ScottPlot.Drawing;
+using ScottPlot.Ticks;
 using System;
 using System.Diagnostics;
 using System.Drawing;
@@ -157,18 +157,35 @@ namespace ScottPlot.Plottable
             }
         }
 
+        private double ClipWithRange(double value, double min, double max, double offset)
+        {
+            double result = value;
+
+            if (result < min)
+                result = min - offset;
+            if (result > max)
+                result = max + offset;
+            return result;
+        }
+
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
             PointF p1, p2;
             if (IsHorizontal)
             {
-                p1 = new PointF(dims.GetPixelX(Min), dims.GetPixelY(dims.YMin));
-                p2 = new PointF(dims.GetPixelX(Max), dims.GetPixelY(dims.YMax));
+                var min = ClipWithRange(Min, dims.XMin, dims.XMax, dims.UnitsPerPxX);
+                var max = ClipWithRange(Max, dims.XMin, dims.XMax, dims.UnitsPerPxX);
+
+                p1 = new PointF(dims.GetPixelX(min), dims.GetPixelY(dims.YMin));
+                p2 = new PointF(dims.GetPixelX(max), dims.GetPixelY(dims.YMax));
             }
             else
             {
-                p1 = new PointF(dims.GetPixelX(dims.XMin), dims.GetPixelY(Min));
-                p2 = new PointF(dims.GetPixelX(dims.XMax), dims.GetPixelY(Max));
+                var min = ClipWithRange(Min, dims.YMin, dims.YMax, dims.UnitsPerPxY);
+                var max = ClipWithRange(Max, dims.YMin, dims.YMax, dims.UnitsPerPxY);
+
+                p1 = new PointF(dims.GetPixelX(dims.XMin), dims.GetPixelY(min));
+                p2 = new PointF(dims.GetPixelX(dims.XMax), dims.GetPixelY(max));
             }
             RectangleF rect = new RectangleF(p1.X - 1, p2.Y - 1, p2.X - p1.X + 1, p1.Y - p2.Y + 1);
 

--- a/src/tests/PlottableRenderTests/AxisSpan.cs
+++ b/src/tests/PlottableRenderTests/AxisSpan.cs
@@ -1,9 +1,6 @@
 ﻿using NUnit.Framework;
-using ScottPlot;
 using ScottPlot.Plottable;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ScottPlotTests.PlottableRenderTests
 {
@@ -59,6 +56,29 @@ namespace ScottPlotTests.PlottableRenderTests
             Console.WriteLine($"After: {after}");
 
             Assert.That(after.IsDarkerThan(before));
+        }
+
+        [Test]
+        public void AxisSpan_ExtremeZoomIn_FullScreenIsSpanColor()
+        {
+            var plt = new ScottPlot.Plot();
+            var axSpan = new HSpan() { X1 = 1, X2 = 10, Color = System.Drawing.Color.Green };
+            plt.Add(axSpan);
+
+            // Initial zoom to fill full plot with span color
+            plt.AxisZoom(10);
+
+            var smallZoomBmp = TestTools.GetLowQualityBitmap(plt);
+            var smallZoom = new MeanPixel(smallZoomBmp);
+
+            // Extreme zoom to prove that full plot filled with span Color
+            plt.AxisZoom(10_000_000);
+
+            var extremeZoomBmp = TestTools.GetLowQualityBitmap(plt);
+            var extremeZoom = new MeanPixel(extremeZoomBmp);
+
+            // Compare mean pixel with delta, because different ticks
+            Assert.AreEqual(smallZoom.RGB, extremeZoom.RGB, 1.0);
         }
     }
 }

--- a/src/tests/PlottableRenderTests/AxisSpan.cs
+++ b/src/tests/PlottableRenderTests/AxisSpan.cs
@@ -59,7 +59,7 @@ namespace ScottPlotTests.PlottableRenderTests
         }
 
         [Test]
-        public void AxisSpan_ExtremeZoomIn_FullScreenIsSpanColor()
+        public void AxisHSpan_ExtremeZoomIn_FullScreenIsSpanColor()
         {
             var plt = new ScottPlot.Plot();
             var axSpan = new HSpan() { X1 = 1, X2 = 10, Color = System.Drawing.Color.Green };
@@ -79,6 +79,30 @@ namespace ScottPlotTests.PlottableRenderTests
 
             // Compare mean pixel with delta, because different ticks
             Assert.AreEqual(smallZoom.RGB, extremeZoom.RGB, 1.0);
+        }
+
+        [Test]
+        public void AxisVSpan_ExtremeZoomIn_FullScreenIsSpanColor()
+        {
+            var plt = new ScottPlot.Plot();
+            var axSpan = new VSpan() { Y1 = 1, Y2 = 10, Color = System.Drawing.Color.Green };
+            plt.Add(axSpan);
+
+            // Initial zoom to fill full plot with span color
+            plt.AxisZoom(1, 10);
+
+            var smallZoomBmp = TestTools.GetLowQualityBitmap(plt);
+            var smallZoom = new MeanPixel(smallZoomBmp);
+
+            // Extreme zoom to prove that full plot filled with span Color
+            plt.AxisZoom(1, 10_000_000);
+
+            var extremeZoomBmp = TestTools.GetLowQualityBitmap(plt);
+            var extremeZoom = new MeanPixel(extremeZoomBmp);
+
+            // Compare mean pixel with delta, because different ticks
+            // Y Ticks has more affect on mean pixel
+            Assert.AreEqual(smallZoom.RGB, extremeZoom.RGB, 10);
         }
     }
 }

--- a/src/tests/PlottableRenderTests/AxisSpan.cs
+++ b/src/tests/PlottableRenderTests/AxisSpan.cs
@@ -102,7 +102,7 @@ namespace ScottPlotTests.PlottableRenderTests
 
             // Compare mean pixel with delta, because different ticks
             // Y Ticks has more affect on mean pixel
-            Assert.AreEqual(smallZoom.RGB, extremeZoom.RGB, 10);
+            Assert.AreEqual(smallZoom.RGB, extremeZoom.RGB, 20);
         }
     }
 }


### PR DESCRIPTION
**Purpose:** (bug fix)

Then zoom to `AxisSpan`, it shoud fill whole plot with its color. But on extreme zoom `AxisSpan` disapear.
This is a known `GDI+` bug with clipping objects that go far beyond the clipping region.
To fix bug, this PR manually clip `AxisSpan` by 1 pixel more then `Plottable area` before passing it to` GDI+`.

Additional added 2 integration tests that reproduce this bug.
This tests fails without this PR fix.