### PR TITLE
Fixes transparency threshold to compare with normalized values

### DIFF
--- a/src/ScottPlot/Drawing/Colormap.cs
+++ b/src/ScottPlot/Drawing/Colormap.cs
@@ -131,9 +131,31 @@ namespace ScottPlot.Drawing
             {
                 byte pixelIntensity = (byte)Math.Max(Math.Min(intensities[i] * 255, 255), 0);
                 var (r, g, b) = colorMap.GetRGB(pixelIntensity);
-                byte alpha = intensities[i] < minimumIntensity ? (byte)0 : (byte)255;
+                byte alpha = pixelIntensity < minimumIntensity ? (byte)0 : (byte)255;
                 byte[] argb = { b, g, r, alpha };
                 rgbas[i] = BitConverter.ToInt32(argb, 0);
+            }
+            return rgbas;
+        }
+
+        public static int[] GetRGBAs(double?[] intensities, Colormap colorMap, double minimumIntensity = 0)
+        {
+            int[] rgbas = new int[intensities.Length];
+            for (int i = 0; i < intensities.Length; i++)
+            {
+                if (intensities[i].HasValue)
+                {
+                    byte pixelIntensity = (byte)Math.Max(Math.Min(intensities[i].Value * 255, 255), 0);
+                    var (r, g, b) = colorMap.GetRGB(pixelIntensity);
+                    byte alpha = pixelIntensity < minimumIntensity ? (byte)0 : (byte)255;
+                    byte[] argb = { b, g, r, alpha };
+                    rgbas[i] = BitConverter.ToInt32(argb, 0);
+                }
+                else
+                {
+                    byte[] argb = { 0, 0, 0, 0 };
+                    rgbas[i] = BitConverter.ToInt32(argb, 0);
+                }
             }
             return rgbas;
         }

--- a/src/ScottPlot/Drawing/Colormap.cs
+++ b/src/ScottPlot/Drawing/Colormap.cs
@@ -131,7 +131,7 @@ namespace ScottPlot.Drawing
             {
                 byte pixelIntensity = (byte)Math.Max(Math.Min(intensities[i] * 255, 255), 0);
                 var (r, g, b) = colorMap.GetRGB(pixelIntensity);
-                byte alpha = pixelIntensity < minimumIntensity ? (byte)0 : (byte)255;
+                byte alpha = intensities[i] < minimumIntensity ? (byte)0 : (byte)255;
                 byte[] argb = { b, g, r, alpha };
                 rgbas[i] = BitConverter.ToInt32(argb, 0);
             }
@@ -147,7 +147,7 @@ namespace ScottPlot.Drawing
                 {
                     byte pixelIntensity = (byte)Math.Max(Math.Min(intensities[i].Value * 255, 255), 0);
                     var (r, g, b) = colorMap.GetRGB(pixelIntensity);
-                    byte alpha = pixelIntensity < minimumIntensity ? (byte)0 : (byte)255;
+                    byte alpha = intensities[i] < minimumIntensity ? (byte)0 : (byte)255;
                     byte[] argb = { b, g, r, alpha };
                     rgbas[i] = BitConverter.ToInt32(argb, 0);
                 }

--- a/src/ScottPlot/Drawing/Colormap.cs
+++ b/src/ScottPlot/Drawing/Colormap.cs
@@ -131,7 +131,7 @@ namespace ScottPlot.Drawing
             {
                 byte pixelIntensity = (byte)Math.Max(Math.Min(intensities[i] * 255, 255), 0);
                 var (r, g, b) = colorMap.GetRGB(pixelIntensity);
-                byte alpha = pixelIntensity < minimumIntensity ? (byte)0 : (byte)255;
+                byte alpha = intensities[i] < minimumIntensity ? (byte)0 : (byte)255;
                 byte[] argb = { b, g, r, alpha };
                 rgbas[i] = BitConverter.ToInt32(argb, 0);
             }

--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -411,6 +411,33 @@ namespace ScottPlot
 
         [Obsolete("Create this plottable manually with new, then Add() it to the plot.")]
         public Heatmap PlotHeatmap(
+            double[,] intensities,
+            Drawing.Colormap colormap = null,
+            string label = null,
+            double[] axisOffsets = null,
+            double[] axisMultipliers = null,
+            double? scaleMin = null,
+            double? scaleMax = null,
+            double? transparencyThreshold = null,
+            Bitmap backgroundImage = null,
+            bool displayImageAbove = false,
+            bool drawAxisLabels = true
+            )
+        {
+            double?[,] tmp = new double?[intensities.GetLength(0), intensities.GetLength(1)];
+            for (int i = 0; i < intensities.GetLength(0); i++)
+            {
+                for (int j = 0; j < intensities.GetLength(1); j++)
+                {
+                    tmp[i, j] = intensities[i, j];
+                }
+            }
+
+            return PlotHeatmap(tmp, colormap, label, axisOffsets, axisMultipliers, scaleMin, scaleMax, transparencyThreshold, backgroundImage, displayImageAbove, drawAxisLabels);
+        }
+
+        [Obsolete("Create this plottable manually with new, then Add() it to the plot.")]
+        public Heatmap PlotHeatmap(
             double?[,] intensities,
             Drawing.Colormap colormap = null,
             string label = null,

--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -411,7 +411,7 @@ namespace ScottPlot
 
         [Obsolete("Create this plottable manually with new, then Add() it to the plot.")]
         public Heatmap PlotHeatmap(
-            double[,] intensities,
+            double?[,] intensities,
             Drawing.Colormap colormap = null,
             string label = null,
             double[] axisOffsets = null,

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -26,6 +26,7 @@ namespace ScottPlot.Plottable
         public double? ScaleMin;
         public double? ScaleMax;
         public double? TransparencyThreshold;
+        public double? TransparencyThresholdNormalized;
         public Bitmap BackgroundImage;
         public bool DisplayImageAbove;
         public bool ShowAxisLabels;
@@ -47,11 +48,11 @@ namespace ScottPlot.Plottable
             double normalizeMax = (ScaleMax.HasValue && ScaleMax.Value > Max) ? ScaleMax.Value : Max;
 
             if (TransparencyThreshold.HasValue)
-                TransparencyThreshold = Normalize(TransparencyThreshold.Value, Min, Max, ScaleMin, ScaleMax);
+                TransparencyThresholdNormalized = Normalize(TransparencyThreshold.Value, Min, Max, ScaleMin, ScaleMax);
 
             NormalizedIntensities = Normalize(intensitiesFlattened, null, null, ScaleMin, ScaleMax);
 
-            int[] flatARGB = Colormap.GetRGBAs(NormalizedIntensities, Colormap, minimumIntensity: TransparencyThreshold ?? 0);
+            int[] flatARGB = Colormap.GetRGBAs(NormalizedIntensities, Colormap, minimumIntensity: TransparencyThresholdNormalized ?? 0);
             double[] normalizedValues = Normalize(Enumerable.Range(0, 256).Select(i => (double)i).Reverse().ToArray(), null, null, ScaleMin, ScaleMax);
             int[] scaleRGBA = Colormap.GetRGBAs(normalizedValues, Colormap);
 

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -45,6 +45,10 @@ namespace ScottPlot.Plottable
 
             foreach (double? curr in intensitiesFlattened)
             {
+                if (curr.HasValue && double.IsNaN(curr.Value))
+                {
+                    throw new ArgumentException("Heatmaps do not support intensities of double.NaN");
+                }
                 if (curr.HasValue && curr.Value < Min)
                 {
                     Min = curr.Value;

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -10,7 +10,7 @@ namespace ScottPlot.Plottable
     public class Heatmap : IPlottable
     {
         // these fields are updated when the intensities are analyzed
-        private double[] NormalizedIntensities;
+        private double?[] NormalizedIntensities;
         private double Min;
         private double Max;
         private int Width;
@@ -26,7 +26,6 @@ namespace ScottPlot.Plottable
         public double? ScaleMin;
         public double? ScaleMax;
         public double? TransparencyThreshold;
-        public double? TransparencyThresholdNormalized;
         public Bitmap BackgroundImage;
         public bool DisplayImageAbove;
         public bool ShowAxisLabels;
@@ -35,25 +34,38 @@ namespace ScottPlot.Plottable
         public int YAxisIndex { get; set; } = 0;
 
         // call this externally if data changes
-        public void UpdateData(double[,] intensities)
+        public void UpdateData(double?[,] intensities)
         {
             Width = intensities.GetLength(1);
             Height = intensities.GetLength(0);
 
-            double[] intensitiesFlattened = intensities.Cast<double>().ToArray();
-            Min = intensitiesFlattened.Min();
-            Max = intensitiesFlattened.Max();
+            double?[] intensitiesFlattened = intensities.Cast<double?>().ToArray();
+            Min = double.PositiveInfinity;
+            Max = double.NegativeInfinity;
+
+            foreach (double? curr in intensitiesFlattened)
+            {
+                if (curr.HasValue && curr.Value < Min)
+                {
+                    Min = curr.Value;
+                }
+
+                if (curr.HasValue && curr.Value > Max)
+                {
+                    Max = curr.Value;
+                }
+            }
 
             double normalizeMin = (ScaleMin.HasValue && ScaleMin.Value < Min) ? ScaleMin.Value : Min;
             double normalizeMax = (ScaleMax.HasValue && ScaleMax.Value > Max) ? ScaleMax.Value : Max;
 
             if (TransparencyThreshold.HasValue)
-                TransparencyThresholdNormalized = Normalize(TransparencyThreshold.Value, Min, Max, ScaleMin, ScaleMax);
+                TransparencyThreshold = Normalize(TransparencyThreshold.Value, Min, Max, ScaleMin, ScaleMax);
 
             NormalizedIntensities = Normalize(intensitiesFlattened, null, null, ScaleMin, ScaleMax);
 
-            int[] flatARGB = Colormap.GetRGBAs(NormalizedIntensities, Colormap, minimumIntensity: TransparencyThresholdNormalized ?? 0);
-            double[] normalizedValues = Normalize(Enumerable.Range(0, 256).Select(i => (double)i).Reverse().ToArray(), null, null, ScaleMin, ScaleMax);
+            int[] flatARGB = Colormap.GetRGBAs(NormalizedIntensities, Colormap, minimumIntensity: TransparencyThreshold ?? 0);
+            double?[] normalizedValues = Normalize(Enumerable.Range(0, 256).Select(i => (double?)i).Reverse().ToArray(), null, null, ScaleMin, ScaleMax);
             int[] scaleRGBA = Colormap.GetRGBAs(normalizedValues, Colormap);
 
             BmpHeatmap?.Dispose();
@@ -70,18 +82,27 @@ namespace ScottPlot.Plottable
             BmpScale.UnlockBits(scaleBmpData);
         }
 
-        private double Normalize(double input, double? min = null, double? max = null, double? scaleMin = null, double? scaleMax = null)
-            => Normalize(new double[] { input }, min, max, scaleMin, scaleMax)[0];
+        private double? Normalize(double? input, double? min = null, double? max = null, double? scaleMin = null, double? scaleMax = null)
+            => Normalize(new double?[] { input }, min, max, scaleMin, scaleMax)[0];
 
-        private double[] Normalize(double[] input, double? min = null, double? max = null, double? scaleMin = null, double? scaleMax = null)
+        private double?[] Normalize(double?[] input, double? min = null, double? max = null, double? scaleMin = null, double? scaleMax = null)
         {
+            double? NormalizePreserveNull(double? i)
+            {
+                if (i.HasValue)
+                {
+                    return (i.Value - min.Value) / (max.Value - min.Value);
+                }
+                return null;
+            }
+
             min = min ?? input.Min();
             max = max ?? input.Max();
 
             min = (scaleMin.HasValue && scaleMin.Value < min) ? scaleMin.Value : min;
             max = (scaleMax.HasValue && scaleMax.Value > max) ? scaleMax.Value : max;
 
-            double[] normalized = input.AsParallel().AsOrdered().Select(i => (i - min.Value) / (max.Value - min.Value)).ToArray();
+            double?[] normalized = input.AsParallel().AsOrdered().Select<double?, double?>(i => NormalizePreserveNull(i)).ToArray();
 
             if (scaleMin.HasValue)
             {

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -82,6 +82,20 @@ namespace ScottPlot.Plottable
             BmpScale.UnlockBits(scaleBmpData);
         }
 
+        public void UpdateData(double[,] intensities)
+        {
+            double?[,] tmp = new double?[intensities.GetLength(0), intensities.GetLength(1)];
+            for (int i = 0; i < intensities.GetLength(0); i++)
+            {
+                for (int j = 0; j < intensities.GetLength(1); j++)
+                {
+                    tmp[i, j] = intensities[i, j];
+                }
+            }
+
+            UpdateData(tmp);
+        }
+
         private double? Normalize(double? input, double? min = null, double? max = null, double? scaleMin = null, double? scaleMax = null)
             => Normalize(new double?[] { input }, min, max, scaleMin, scaleMax)[0];
 

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/ColormapViewer.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/ColormapViewer.cs
@@ -31,7 +31,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
 
         private void Redraw()
         {
-            Drawing.Colormap cmap = colormaps[lbColormapNames.SelectedIndex];
+            Drawing.Colormap cmap = colormaps[lbColormapNames.SelectedIndex >= 0 ? lbColormapNames.SelectedIndex : 0];
             lblColormap.Text = cmap.Name;
 
             pbColormap.Image?.Dispose();


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Currently when using the `TransparencyThreshold` parameter on heatmaps it compares the intensity on a range from 0 to 255 to the given threshold. This threshold, however, is given on a range from 0 to 1. This PR corrects that issue.

**New Functionality:**
N/A