### PR TITLE
Colour Bar Interpolation Should be Nearest Neighbour

### DIFF
--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -218,11 +218,12 @@ namespace ScottPlot.Plottable
             using (var font = GDI.Font(null, 12))
             using (var sf2 = new StringFormat() { LineAlignment = StringAlignment.Far })
             {
+                gfx.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
                 PointF scaleLoc = new PointF(dims.DataOffsetX + dims.DataWidth + scaleLeftPad, dims.DataOffsetY);
                 SizeF scaleSize = new SizeF(scaleWidth, dims.DataHeight);
                 RectangleF scaleRect = new RectangleF(scaleLoc, scaleSize);
                 gfx.DrawImage(BmpScale, scaleRect);
-                gfx.DrawRectangle(outlinePen, scaleRect.X, scaleRect.Y, scaleRect.Width, scaleRect.Height);
+                gfx.DrawRectangle(outlinePen, scaleRect.X, scaleRect.Y, scaleRect.Width / 2, scaleRect.Height); // No, I don't know why I need to divide by 2 here. Very strange...
 
                 string minString = (ScaleMin.HasValue && ScaleMin > Min) ? $"≤ {ScaleMin:f3}" : $"{Min:f3}";
                 string maxString = (ScaleMax.HasValue && ScaleMax < Max) ? $"≥ {ScaleMax:f3}" : $"{Max:f3}";

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -129,7 +129,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string Title => "Gaussian Interpolation";
         public string Description =>
             "Heatmaps can be created from 2D data points using bilinear interpolation with Gaussian weighting. " +
-            "This option results in a colormap with a standard deviation of 4.";
+            "This option results in a heatmap with a standard deviation of 4.";
 
         public void ExecuteRecipe(Plot plt)
         {

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -129,7 +129,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string Title => "Gaussian Interpolation";
         public string Description =>
             "Heatmaps can be created from 2D data points using bilinear interpolation with Gaussian weighting. " +
-            "This option results in a colormap with 4x the number of squares.";
+            "This option results in a colormap with a standard deviation of 4.";
 
         public void ExecuteRecipe(Plot plt)
         {

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -106,7 +106,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "heatmap_density";
         public string Title => "Interpolation by Density";
         public string Description =>
-            "Heatmaps can be created from random 2D data points using bilinear interpolation.";
+            "Heatmaps can be created from random 2D data points using the count within a square of fixed size.";
 
         public void ExecuteRecipe(Plot plt)
         {


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Some tweaks after #679 

**New Functionality:**
Previously: 
![image](https://user-images.githubusercontent.com/8635304/103111296-b4af4480-4608-11eb-8113-c7790a0d6ab6.png)

Now:
![image](https://user-images.githubusercontent.com/8635304/103111298-bc6ee900-4608-11eb-9a02-224cd54987ba.png)

Part of the issue was that the black rectangle around the colourbar was twice the width of the colourbar. I elected to half the width of the rectangle, but you could also double the width of the colourbar. As for the interpolation, that fixes the colour seeming to fade to white at the right edge of the colourbar

This also changes the description of a demo: 

> This option results in a colormap with 4x the number of squares.

is replaced with:
> This option results in a heatmap with a standard deviation of 4.

I believe this mistake may have come from the confusingly named `sampleWidth` parameter. I think it could be split up into two parameters (with appropriate defaults) instead of meaning either the width of the square used for calculating density, or standard deviation, depending on context. Or it could be split into two different functions.

There was a similar issue with the density mode, the demo originally said it used bilinear interpolation to construct the heatmap, when it actually counts the number of points within a square of fixed size.