### PR TITLE
Colorbar Plottable

### DIFF
--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -168,6 +168,17 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Add a colorbar to display a colormap beside the data area
+        /// </summary>
+        public Colorbar AddColorbar(Drawing.Colormap colormap = null, int space = 100)
+        {
+            var plottable = new Colorbar(colormap);
+            Add(plottable);
+            YAxis2.SetSizeLimit(min: space);
+            return plottable;
+        }
+
+        /// <summary>
         /// Create a polygon to fill the area between Y values and a baseline.
         /// </summary>
         public Polygon AddFill(double[] xs, double[] ys, double baseline = 0, Color? color = null)
@@ -273,13 +284,15 @@ namespace ScottPlot
         /// <summary>
         /// Add a heatmap to the plot
         /// </summary>
-        public Heatmap AddHeatmap(double[,] initialData, int scalebarSpace = 100, bool lockScales = true)
+        public Heatmap AddHeatmap(double[,] intensities, bool lockScales = true, Drawing.Colormap colormap = null)
         {
+            if (lockScales)
+                AxisScaleLock(true);
+
             var plottable = new Heatmap();
-            plottable.Update(initialData);
+            plottable.Update(intensities, colormap);
             Add(plottable);
-            YAxis2.SetSizeLimit(min: scalebarSpace);
-            AxisScaleLock(lockScales);
+
             return plottable;
         }
 

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -172,10 +172,23 @@ namespace ScottPlot
         /// </summary>
         public Colorbar AddColorbar(Drawing.Colormap colormap = null, int space = 100)
         {
-            var plottable = new Colorbar(colormap);
-            Add(plottable);
+            var cb = new Colorbar(colormap);
+            Add(cb);
             YAxis2.SetSizeLimit(min: space);
-            return plottable;
+            return cb;
+        }
+
+        /// <summary>
+        /// Add a colorbar initialized with settings from a heatmap
+        /// </summary>
+        public Colorbar AddColorbar(Heatmap heatmap, int space = 100)
+        {
+            var cb = new Colorbar(heatmap.Colormap);
+            cb.AddTick(0, heatmap.ColorbarMin);
+            cb.AddTick(1, heatmap.ColorbarMax);
+            Add(cb);
+            YAxis2.SetSizeLimit(min: space);
+            return cb;
         }
 
         /// <summary>
@@ -284,7 +297,7 @@ namespace ScottPlot
         /// <summary>
         /// Add a heatmap to the plot
         /// </summary>
-        public Heatmap AddHeatmap(double[,] intensities, bool lockScales = true, Drawing.Colormap colormap = null)
+        public Heatmap AddHeatmap(double[,] intensities, Drawing.Colormap colormap = null, bool lockScales = true)
         {
             if (lockScales)
                 AxisScaleLock(true);

--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -456,14 +456,12 @@ namespace ScottPlot
                 Label = label,
                 AxisOffsets = axisOffsets ?? new double[] { 0, 0 },
                 AxisMultipliers = axisMultipliers ?? new double[] { 1, 1 },
-                ScaleMin = scaleMin,
-                ScaleMax = scaleMax,
                 TransparencyThreshold = transparencyThreshold,
                 BackgroundImage = backgroundImage,
                 DisplayImageAbove = displayImageAbove,
                 ShowAxisLabels = drawAxisLabels,
             };
-            heatmap.Update(intensities);
+            heatmap.Update(intensities, colormap ?? Drawing.Colormap.Viridis, scaleMin, scaleMax);
 
             Add(heatmap);
             Layout(top: 180);

--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -462,7 +462,6 @@ namespace ScottPlot
                 BackgroundImage = backgroundImage,
                 DisplayImageAbove = displayImageAbove,
                 ShowAxisLabels = drawAxisLabels,
-                Colormap = colormap ?? Drawing.Colormap.Viridis
             };
             heatmap.Update(intensities);
 

--- a/src/ScottPlot/Plottable/Colorbar.cs
+++ b/src/ScottPlot/Plottable/Colorbar.cs
@@ -83,10 +83,15 @@ namespace ScottPlot.Plottable
 
         private void UpdateBitmap()
         {
-            int valueCount = 256;
             BmpScale?.Dispose();
-            BmpScale = Colormap.Colorbar(Colormap, width: Width, height: valueCount, vertical: true);
+            BmpScale = GetBitmap();
         }
+
+        public Bitmap GetBitmap() =>
+            Colormap.Colorbar(Colormap, Width, 256, true);
+
+        public Bitmap GetBitmap(int width, int height, bool vertical = true) =>
+            Colormap.Colorbar(Colormap, width, height, vertical);
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {

--- a/src/ScottPlot/Plottable/Colorbar.cs
+++ b/src/ScottPlot/Plottable/Colorbar.cs
@@ -1,0 +1,142 @@
+﻿using ScottPlot.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace ScottPlot.Plottable
+{
+    public class Colorbar : IPlottable
+    {
+        public Renderable.Edge Edge = Renderable.Edge.Right;
+
+        private Colormap Colormap;
+        private Bitmap BmpScale;
+        private readonly List<string> TickLabels = new List<string>();
+        private readonly List<double> TickFractions = new List<double>();
+
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get => 0; set { } }
+        public int YAxisIndex { get => 0; set { } }
+        public int Width = 20;
+
+        public Colorbar(Colormap colormap = null)
+        {
+            UpdateColormap(colormap ?? Colormap.Viridis);
+        }
+
+        public void ClearTicks()
+        {
+            TickFractions.Clear();
+            TickLabels.Clear();
+        }
+
+        public void AddTick(double fraction, string label)
+        {
+            TickFractions.Add(fraction);
+            TickLabels.Add(label);
+        }
+
+        public void AddTicks(double[] fractions, string[] labels)
+        {
+            if (fractions.Length != labels.Length)
+                throw new ArgumentException("fractions and labels must have the same length");
+
+            for (int i = 0; i < fractions.Length; i++)
+            {
+                TickFractions.Add(fractions[i]);
+                TickLabels.Add(labels[i]);
+            }
+        }
+
+        public void SetTicks(string minTickLabel, string maxTickLabel)
+        {
+            ClearTicks();
+            AddTick(0, minTickLabel);
+            AddTick(1, maxTickLabel);
+        }
+
+        public void SetTicks(double[] fractions, string[] labels)
+        {
+            ClearTicks();
+            AddTicks(fractions, labels);
+        }
+
+        public LegendItem[] GetLegendItems() => null;
+
+        public AxisLimits GetAxisLimits() => new AxisLimits();
+
+        public void ValidateData(bool deep = false)
+        {
+            if (TickLabels.Count != TickFractions.Count)
+                throw new InvalidOperationException("Tick labels and positions must have the same length");
+        }
+
+        public void UpdateColormap(Colormap newColormap)
+        {
+            Colormap = newColormap;
+            UpdateBitmap();
+        }
+
+        private void UpdateBitmap()
+        {
+            int valueCount = 256;
+            BmpScale?.Dispose();
+            BmpScale = Colormap.Colorbar(Colormap, width: Width, height: valueCount, vertical: true);
+        }
+
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            if (BmpScale is null)
+                UpdateBitmap();
+
+            RectangleF colorbarRect = RenderColorbar(dims, bmp);
+            RenderTicks(dims, bmp, lowQuality, colorbarRect);
+        }
+
+        private RectangleF RenderColorbar(PlotDimensions dims, Bitmap bmp)
+        {
+            float scaleLeftPad = 10;
+
+            PointF location = new PointF(dims.DataOffsetX + dims.DataWidth + scaleLeftPad, dims.DataOffsetY);
+            SizeF size = new SizeF(Width, dims.DataHeight);
+            RectangleF rect = new RectangleF(location, size);
+
+            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality: true, clipToDataArea: false))
+            using (var pen = GDI.Pen(Color.Black))
+            {
+                gfx.DrawImage(BmpScale, location.X, location.Y, size.Width, size.Height + 1);
+                gfx.DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
+            }
+
+            return rect;
+        }
+
+        private void RenderTicks(PlotDimensions dims, Bitmap bmp, bool lowQuality, RectangleF colorbarRect)
+        {
+            float tickLengh = 4;
+            float tickLabelPadding = 2;
+
+            float tickLeftPx = colorbarRect.Right;
+            float tickRightPx = tickLeftPx + tickLengh;
+            float tickLabelPx = tickRightPx + tickLabelPadding;
+
+            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality, false))
+            using (var pen = GDI.Pen(Color.Black))
+            using (var brush = GDI.Brush(Color.Black))
+            using (var font = GDI.Font(null, 12))
+            using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center })
+            {
+                for (int i = 0; i < TickLabels.Count; i++)
+                {
+                    float y = colorbarRect.Top + (float)((1 - TickFractions[i]) * colorbarRect.Height);
+                    gfx.DrawLine(pen, tickLeftPx, y, tickRightPx, y);
+                    gfx.DrawString(TickLabels[i], font, brush, tickLabelPx, y, sf);
+                }
+            }
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/Colorbar.cs
+++ b/src/ScottPlot/Plottable/Colorbar.cs
@@ -52,13 +52,6 @@ namespace ScottPlot.Plottable
             }
         }
 
-        public void SetTicks(string minTickLabel, string maxTickLabel)
-        {
-            ClearTicks();
-            AddTick(0, minTickLabel);
-            AddTick(1, maxTickLabel);
-        }
-
         public void SetTicks(double[] fractions, string[] labels)
         {
             ClearTicks();

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Colorbar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Colorbar.cs
@@ -10,7 +10,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "colorbar_quickstart";
         public string Title => "Colorbar";
         public string Description =>
-            "A colorbar displays a colormap beside the data area. " + 
+            "A colorbar displays a colormap beside the data area. " +
             "Colorbars are typically added to plots containing heatmaps.";
 
         public void ExecuteRecipe(Plot plt)
@@ -39,7 +39,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "colorbar_ticks";
         public string Title => "Colorbar Ticks";
         public string Description =>
-            "Tick marks can be added to colorbars. Each tick is described by a position " + 
+            "Tick marks can be added to colorbars. Each tick is described by a position " +
             "(a fraction of the distance from the bottom to the top) and a string (the tick label).";
 
         public void ExecuteRecipe(Plot plt)

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Colorbar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Colorbar.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ScottPlot.Cookbook.Recipes.Plottable
+{
+    public class Colorbar : IRecipe
+    {
+        public string Category => "Plottable: Colorbar";
+        public string ID => "colorbar_quickstart";
+        public string Title => "Colorbar";
+        public string Description =>
+            "A colorbar displays a colormap beside the data area. " + 
+            "Colorbars are typically added to plots containing heatmaps.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddColorbar();
+        }
+    }
+
+    public class ColorbarColormap : IRecipe
+    {
+        public string Category => "Plottable: Colorbar";
+        public string ID => "colorbar_colormap";
+        public string Title => "Colorbar for Colormap";
+        public string Description =>
+            "By default colorbars use the Viridis colormap, but this behavior can be customized and many colormaps are available.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddColorbar(Drawing.Colormap.Turbo);
+        }
+    }
+
+    public class ColorbarTicks : IRecipe
+    {
+        public string Category => "Plottable: Colorbar";
+        public string ID => "colorbar_ticks";
+        public string Title => "Colorbar Ticks";
+        public string Description =>
+            "Tick marks can be added to colorbars. Each tick is described by a position " + 
+            "(a fraction of the distance from the bottom to the top) and a string (the tick label).";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            var cb = plt.AddColorbar();
+            cb.AddTick(0, "-123");
+            cb.AddTick(1, "+123");
+            cb.AddTick(.5, "0");
+            cb.AddTick(.25, "-61.5");
+            cb.AddTick(.75, "+61.5");
+        }
+    }
+}

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -22,6 +22,25 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         }
     }
 
+    public class HeatmapColorbar : IRecipe
+    {
+        public string Category => "Plottable: Heatmap";
+        public string ID => "heatmap_colorbar";
+        public string Title => "Heatmap with Colorbar";
+        public string Description =>
+            "Heatmaps display a 2D array using a colormap.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[,] data2D = { { 1, 2, 3 },
+                                 { 4, 5, 6 } };
+
+            var hm = plt.AddHeatmap(data2D);
+            var cb = plt.AddColorbar(hm.Colormap);
+            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+        }
+    }
+
     public class HeatmapImage : IRecipe
     {
         public string Category => "Plottable: Heatmap";
@@ -33,7 +52,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public void ExecuteRecipe(Plot plt)
         {
             double[,] imageData = DataGen.SampleImageData();
-            var heatmap = plt.AddHeatmap(imageData);
+            plt.AddHeatmap(imageData);
         }
     }
 
@@ -56,7 +75,9 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 for (int y = 0; y < height; y++)
                     intensities[x, y] = (Math.Sin(x * .2) + Math.Cos(y * .2)) * 100;
 
-            plt.AddHeatmap(intensities);
+            var hm = plt.AddHeatmap(intensities);
+            var cb = plt.AddColorbar(hm.Colormap);
+            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
         }
     }
 
@@ -75,8 +96,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 for (int y = 0; y < 100; y++)
                     intensities[x, y] = (Math.Sin(x * .2) + Math.Cos(y * .2)) * 100;
 
-            var heatmap = plt.AddHeatmap(intensities);
-            heatmap.Update(intensities, Drawing.Colormap.Turbo);
+            var hm = plt.AddHeatmap(intensities);
+            hm.Update(intensities, Drawing.Colormap.Turbo);
+
+            var cb = plt.AddColorbar(hm.Colormap);
+            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
         }
     }
 
@@ -95,8 +119,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 for (int y = 0; y < 100; y++)
                     intensities[x, y] = (Math.Sin(x * .2) + Math.Cos(y * .2)) * 100;
 
-            var heatmap = plt.AddHeatmap(intensities);
-            heatmap.Update(intensities, min: 0, max: 200);
+            var hm = plt.AddHeatmap(intensities);
+            hm.Update(intensities, min: 0, max: 200);
+
+            var cb = plt.AddColorbar(hm.Colormap);
+            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
         }
     }
 
@@ -117,8 +144,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[,] intensities = Tools.XYToIntensities(mode: IntensityMode.Density,
                 xs: xs, ys: ys, width: 50, height: 50, sampleWidth: 4);
 
-            var heatmap = plt.AddHeatmap(intensities);
-            heatmap.Update(intensities);
+            var hm = plt.AddHeatmap(intensities);
+            hm.Update(intensities);
+
+            var cb = plt.AddColorbar(hm.Colormap);
+            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
         }
     }
 
@@ -140,8 +170,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[,] intensities = Tools.XYToIntensities(mode: IntensityMode.Gaussian,
                 xs: xs, ys: ys, width: 50, height: 50, sampleWidth: 4);
 
-            var heatmap = plt.AddHeatmap(intensities);
-            heatmap.Update(intensities);
+            var hm = plt.AddHeatmap(intensities);
+            hm.Update(intensities);
+
+            var cb = plt.AddColorbar(hm.Colormap);
+            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -133,7 +133,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "heatmap_density";
         public string Title => "Interpolation by Density";
         public string Description =>
-            "Heatmaps can be created from random 2D data points using bilinear interpolation.";
+            "Heatmaps can be created from random 2D data points using the count within a square of fixed size.";
 
         public void ExecuteRecipe(Plot plt)
         {
@@ -159,7 +159,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string Title => "Gaussian Interpolation";
         public string Description =>
             "Heatmaps can be created from 2D data points using bilinear interpolation with Gaussian weighting. " +
-            "This option results in a colormap with 4x the number of squares.";
+            "This option results in a heatmap with a standard deviation of 4.";
 
         public void ExecuteRecipe(Plot plt)
         {

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -28,7 +28,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "heatmap_colorbar";
         public string Title => "Heatmap with Colorbar";
         public string Description =>
-            "Heatmaps display a 2D array using a colormap.";
+            "Colorbars are often added when heatmaps are used.";
 
         public void ExecuteRecipe(Plot plt)
         {
@@ -36,8 +36,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                                  { 4, 5, 6 } };
 
             var hm = plt.AddHeatmap(data2D);
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbar(hm);
         }
     }
 
@@ -76,8 +75,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                     intensities[x, y] = (Math.Sin(x * .2) + Math.Cos(y * .2)) * 100;
 
             var hm = plt.AddHeatmap(intensities);
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbar(hm);
         }
     }
 
@@ -96,11 +94,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 for (int y = 0; y < 100; y++)
                     intensities[x, y] = (Math.Sin(x * .2) + Math.Cos(y * .2)) * 100;
 
-            var hm = plt.AddHeatmap(intensities);
-            hm.Update(intensities, Drawing.Colormap.Turbo);
-
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var hm = plt.AddHeatmap(intensities, Drawing.Colormap.Turbo);
+            var cb = plt.AddColorbar(hm);
         }
     }
 
@@ -122,8 +117,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var hm = plt.AddHeatmap(intensities);
             hm.Update(intensities, min: 0, max: 200);
 
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbar(hm);
         }
     }
 
@@ -145,10 +139,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 xs: xs, ys: ys, width: 50, height: 50, sampleWidth: 4);
 
             var hm = plt.AddHeatmap(intensities);
-            hm.Update(intensities);
-
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbar(hm);
         }
     }
 
@@ -171,10 +162,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 xs: xs, ys: ys, width: 50, height: 50, sampleWidth: 4);
 
             var hm = plt.AddHeatmap(intensities);
-            hm.Update(intensities);
-
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbar(hm);
         }
     }
 }

--- a/src/tests/PlottableRenderTests/Colorbar.cs
+++ b/src/tests/PlottableRenderTests/Colorbar.cs
@@ -1,0 +1,45 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.PlottableRenderTests
+{
+    class Colorbar
+    {
+        [Test]
+        public void Test_Colorbar_CanBeAdded()
+        {
+            var plt = new ScottPlot.Plot();
+            var bmp1 = TestTools.GetLowQualityBitmap(plt);
+
+            plt.AddColorbar();
+            var bmp2 = TestTools.GetLowQualityBitmap(plt);
+
+            //TestTools.SaveFig(plt);
+            var before = new MeanPixel(bmp1);
+            var after = new MeanPixel(bmp2);
+            Assert.That(after.IsDarkerThan(before));
+        }
+
+        [Test]
+        public void Test_Colorbar_ColorCanBeChanged()
+        {
+            var plt = new ScottPlot.Plot();
+            var cb = plt.AddColorbar(ScottPlot.Drawing.Colormap.Grayscale);
+            var bmp1 = TestTools.GetLowQualityBitmap(plt);
+
+            cb.UpdateColormap(ScottPlot.Drawing.Colormap.Blues);
+            var bmp2 = TestTools.GetLowQualityBitmap(plt);
+
+            //TestTools.SaveFig(plt);
+            var before = new MeanPixel(bmp1);
+            var after = new MeanPixel(bmp2);
+            Assert.That(before.IsGray());
+            Assert.That(after.IsNotGray());
+            Assert.That(after.IsMoreBlueThan(before));
+        }
+    }
+}


### PR DESCRIPTION
Previously colorbar rendering was achieved inside the heatmap module. This PR gives colorbar its own plot type, and `AddColorbar()` can be called on any plot. This addresses #678

The colorbar could benefit from continued refinement/refactoring (especially the tick system), but this is a strong start.

```cs
var hm = plt.AddHeatmap(intensities);

var cb = plt.AddColorbar(hm.Colormap);
cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
```

![image](https://user-images.githubusercontent.com/4165489/103142952-de38a080-46da-11eb-8201-9174f24d4d24.png)

This PR also makes some changes suggested by #680