### PR TITLE
AddColorbarFromHeatmap and syncing Colorbars with Heatmaps

### DIFF
--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -179,6 +179,18 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Add a colorbar to display a colormap beside the data area
+        /// </summary>
+        /// 
+        public Colorbar AddColorbarFromHeatmap(Heatmap hm, bool synced = true, int space = 100)
+        {
+            var plottable = hm.CreateColorBar(synced);
+            Add(plottable);
+            YAxis2.SetSizeLimit(min: space);
+            return plottable;
+        }
+
+        /// <summary>
         /// Create a polygon to fill the area between Y values and a baseline.
         /// </summary>
         public Polygon AddFill(double[] xs, double[] ys, double baseline = 0, Color? color = null)

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -182,7 +182,7 @@ namespace ScottPlot
         /// Add a colorbar to display a colormap beside the data area
         /// </summary>
         /// 
-        public Colorbar AddColorbarFromHeatmap(Heatmap hm, bool synced = true, int space = 100)
+        public Colorbar AddColorbarFromHeatmap(Heatmap hm, int space = 100, bool synced = true)
         {
             var plottable = hm.CreateColorBar(synced);
             Add(plottable);

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -1,5 +1,6 @@
 ﻿using ScottPlot.Drawing;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Linq;
@@ -9,6 +10,8 @@ namespace ScottPlot.Plottable
 {
     public class Heatmap : IPlottable
     {
+        private List<Colorbar> subscribers = new List<Colorbar>();
+
         // these fields are updated when the intensities are analyzed
         private double Min;
         private double Max;
@@ -36,6 +39,33 @@ namespace ScottPlot.Plottable
             AxisOffsets = new double[] { 0, 0 };
             AxisMultipliers = new double[] { 1, 1 };
             Colormap = Colormap.Viridis;
+        }
+
+        public Colorbar CreateColorBar(bool synced = true)
+        {
+            Colorbar cb = new Colorbar();
+            SyncColorBar(cb);
+
+            if (synced)
+            {
+                subscribers.Add(cb);
+            }
+
+            return cb;
+        }
+
+        private void SyncColorBar(Colorbar cb)
+        {
+            cb.UpdateColormap(Colormap);
+            cb.SetTicks(ColorbarMin, ColorbarMax);
+        }
+
+        private void ModifySubscribers()
+        {
+            foreach (Colorbar curr in subscribers)
+            {
+                SyncColorBar(curr);
+            }
         }
 
         public void Update(double?[,] intensities, Colormap colormap = null, double? min = null, double? max = null)

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -119,6 +119,8 @@ namespace ScottPlot.Plottable
             BitmapData bmpData = BmpHeatmap.LockBits(rect, ImageLockMode.ReadWrite, BmpHeatmap.PixelFormat);
             Marshal.Copy(flatARGB, 0, bmpData.Scan0, flatARGB.Length);
             BmpHeatmap.UnlockBits(bmpData);
+
+            ModifySubscribers();
         }
 
         public string ColorbarMin { get; private set; }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -36,8 +36,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                                  { 4, 5, 6 } };
 
             var hm = plt.AddHeatmap(data2D);
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbarFromHeatmap(hm);
         }
     }
 
@@ -76,8 +75,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                     intensities[x, y] = (Math.Sin(x * .2) + Math.Cos(y * .2)) * 100;
 
             var hm = plt.AddHeatmap(intensities);
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbarFromHeatmap(hm);
         }
     }
 
@@ -99,8 +97,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var hm = plt.AddHeatmap(intensities);
             hm.Update(intensities, Drawing.Colormap.Turbo);
 
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbarFromHeatmap(hm);
         }
     }
 
@@ -122,8 +119,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var hm = plt.AddHeatmap(intensities);
             hm.Update(intensities, min: 0, max: 200);
 
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbarFromHeatmap(hm);
         }
     }
 
@@ -147,8 +143,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var hm = plt.AddHeatmap(intensities);
             hm.Update(intensities);
 
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbarFromHeatmap(hm);
         }
     }
 
@@ -173,8 +168,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var hm = plt.AddHeatmap(intensities);
             hm.Update(intensities);
 
-            var cb = plt.AddColorbar(hm.Colormap);
-            cb.SetTicks(hm.ColorbarMin, hm.ColorbarMax);
+            var cb = plt.AddColorbarFromHeatmap(hm);
         }
     }
 }


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Adds a method `plt.AddColorFromHeatmap` which allows optional syncing Colorbars with a "parent" Heatmap (I don't know if parent is the right term for the observer pattern). Any call to the `Heatmap.Update` method will trigger this syncing.

**New Functionality:**

```cs
Colorbar cb = plt.AddColorbarFromHeatmap(hm);
```

The signature of this method is `public Colorbar AddColorbarFromHeatmap(Heatmap hm, int space = 100, bool synced = true)`, so setting `synced` to `false` lets the user disable syncing (the colorbar will be synced with the heatmap on its creation but it will not be synced to reflect further updates to the heatmap).